### PR TITLE
Initialize RequestError Instance instead of a pointer

### DIFF
--- a/request.go
+++ b/request.go
@@ -87,7 +87,7 @@ func (r *Request) execute(c Client, output interface{}) error {
 	c.cfg.logger.Debugf("Status code returned: %v", result.StatusCode)
 
 	if result.StatusCode >= 300 {
-		errorMessage := new(RequestError) //error messages have a different structure, so they are read with a different struct
+		var errorMessage RequestError //error messages have a different structure, so they are read with a different struct
 		errorMessage.StatusCode = result.StatusCode
 		json.Unmarshal(iostream, &errorMessage)
 		c.cfg.logger.Errorf("Error message: %v. Status: %v. Code: %v.", errorMessage.ErrorMessage, errorMessage.StatusMessage, errorMessage.StatusCode)


### PR DESCRIPTION
as `json.Unmarshal(iostream, &errorMessage)` already takes the pointer (by using `&` symbol). So that we don't need to use new() function. Also it is better to avoid using many new() as the function will create a variable which will escape from our stack memory.