### PR TITLE
remove unnecessary new()

### DIFF
--- a/request.go
+++ b/request.go
@@ -113,10 +113,9 @@ func (c *Client) WaitForRequestCompletion(id string) error {
 			return fmt.Errorf("Timeout reached when waiting for request %v to complete", id)
 		default:
 			time.Sleep(500 * time.Millisecond) //delay the request, so we don't do too many requests to the server
-			response := new(RequestStatus)
+			var response RequestStatus
 			r.execute(*c, &response)
-			output := *response //Without this cast reading indexes doesn't work
-			if output[id].Status == "done" {
+			if response[id].Status == "done" {
 				c.cfg.logger.Info("Done with creating")
 				return nil
 			}

--- a/server.go
+++ b/server.go
@@ -310,7 +310,7 @@ func (c *Client) ShutdownServer(id string) error {
 	r := Request{
 		uri:    path.Join(apiServerBase, id, "shutdown"),
 		method: http.MethodPatch,
-		body:   new(map[string]string),
+		body:   map[string]string{},
 	}
 	err = r.execute(*c, nil)
 	if err != nil {


### PR DESCRIPTION
I have removed unnecessary new() causing variables escaping from stack memory.