### PR TITLE
Bring back "Relations" field when creating a server.

### DIFF
--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -137,6 +137,9 @@ func (c *Client) GetLoadBalancer(id string) (LoadBalancer, error) {
 
 //CreateLoadBalancer creates a new loadbalancer
 func (c *Client) CreateLoadBalancer(body LoadBalancerCreateRequest) (LoadBalancerCreateResponse, error) {
+	if body.Labels == nil {
+		body.Labels = make([]string, 0)
+	}
 	r := Request{
 		uri:    apiLoadBalancerBase,
 		method: http.MethodPost,

--- a/server.go
+++ b/server.go
@@ -46,16 +46,16 @@ type ServerRelations struct {
 
 //ServerCreateRequest JSON struct of a request for creating a server
 type ServerCreateRequest struct {
-	Name            string                        `json:"name"`
-	Memory          int                           `json:"memory"`
-	Cores           int                           `json:"cores"`
-	LocationUUID    string                        `json:"location_uuid"`
-	HardwareProfile string                        `json:"hardware_profile,omitempty"`
-	AvailablityZone string                        `json:"availability_zone,omitempty"`
-	Labels          []string                      `json:"labels,omitempty"`
-	Status          string                        `json:"status,omitempty"`
-	AutoRecovery    *bool                         `json:"auto_recovery,omitempty"`
-	Relations       *ServerCreateRequestRelations `json:"relations,omitempty"`
+	Name            string                       `json:"name"`
+	Memory          int                          `json:"memory"`
+	Cores           int                          `json:"cores"`
+	LocationUUID    string                       `json:"location_uuid"`
+	HardwareProfile string                       `json:"hardware_profile,omitempty"`
+	AvailablityZone string                       `json:"availability_zone,omitempty"`
+	Labels          []string                     `json:"labels,omitempty"`
+	Status          string                       `json:"status,omitempty"`
+	AutoRecovery    *bool                        `json:"auto_recovery,omitempty"`
+	Relations       ServerCreateRequestRelations `json:"relations"`
 }
 
 //ServerCreateRequestRelations JSOn struct of a list of a server's relations
@@ -83,24 +83,24 @@ type ServerPowerUpdateRequest struct {
 
 //ServerCreateRequestStorage JSON struct of a relation between a server and a storage
 type ServerCreateRequestStorage struct {
-	StorageUUID string `json:"storage_uuid,omitempty"`
+	StorageUUID string `json:"storage_uuid"`
 	BootDevice  bool   `json:"bootdevice,omitempty"`
 }
 
 //ServerCreateRequestNetwork JSON struct of a relation between a server and a network
 type ServerCreateRequestNetwork struct {
-	NetworkUUID string `json:"network_uuid,omitempty"`
+	NetworkUUID string `json:"network_uuid"`
 	BootDevice  bool   `json:"bootdevice,omitempty"`
 }
 
 //ServerCreateRequestIP JSON struct of a relation between a server and an IP address
 type ServerCreateRequestIP struct {
-	IPaddrUUID string `json:"ipaddr_uuid,omitempty"`
+	IPaddrUUID string `json:"ipaddr_uuid"`
 }
 
 //ServerCreateRequestIsoimage JSON struct of a relation between a server and an ISO-Image
 type ServerCreateRequestIsoimage struct {
-	IsoimageUUID string `json:"isoimage_uuid,omitempty"`
+	IsoimageUUID string `json:"isoimage_uuid"`
 }
 
 //ServerUpdateRequest JSON of a request for updating a server

--- a/server.go
+++ b/server.go
@@ -46,15 +46,15 @@ type ServerRelations struct {
 
 //ServerCreateRequest JSON struct of a request for creating a server
 type ServerCreateRequest struct {
-	Name            string   `json:"name"`
-	Memory          int      `json:"memory"`
-	Cores           int      `json:"cores"`
-	LocationUUID    string   `json:"location_uuid"`
-	HardwareProfile string   `json:"hardware_profile,omitempty"`
-	AvailablityZone string   `json:"availability_zone,omitempty"`
-	Labels          []string `json:"labels,omitempty"`
-	Status          string   `json:"status,omitempty"`
-	AutoRecovery    *bool    `json:"auto_recovery,omitempty"`
+	Name            string                        `json:"name"`
+	Memory          int                           `json:"memory"`
+	Cores           int                           `json:"cores"`
+	LocationUUID    string                        `json:"location_uuid"`
+	HardwareProfile string                        `json:"hardware_profile,omitempty"`
+	AvailablityZone string                        `json:"availability_zone,omitempty"`
+	Labels          []string                      `json:"labels,omitempty"`
+	Status          string                        `json:"status,omitempty"`
+	AutoRecovery    *bool                         `json:"auto_recovery,omitempty"`
 	Relations       *ServerCreateRequestRelations `json:"relations,omitempty"`
 }
 

--- a/server.go
+++ b/server.go
@@ -55,6 +55,15 @@ type ServerCreateRequest struct {
 	Labels          []string `json:"labels,omitempty"`
 	Status          string   `json:"status,omitempty"`
 	AutoRecovery    *bool    `json:"auto_recovery,omitempty"`
+	Relations       *ServerCreateRequestRelations `json:"relations,omitempty"`
+}
+
+//ServerCreateRequestRelations JSOn struct of a list of a server's relations
+type ServerCreateRequestRelations struct {
+	IsoImages []ServerCreateRequestIsoimage `json:"isoimages"`
+	Networks  []ServerCreateRequestNetwork  `json:"networks"`
+	PublicIPs []ServerCreateRequestIP       `json:"public_ips"`
+	Storages  []ServerCreateRequestStorage  `json:"storages"`
 }
 
 //ServerCreateResponse JSON struct of a response for creating a server
@@ -182,6 +191,21 @@ func (c *Client) GetServerList() ([]Server, error) {
 
 //CreateServer create a server
 func (c *Client) CreateServer(body ServerCreateRequest) (ServerCreateResponse, error) {
+	//check if these slices are nil
+	//make them be empty slice instead of nil
+	//so that JSON structure will be valid
+	if body.Relations.PublicIPs == nil {
+		body.Relations.PublicIPs = make([]ServerCreateRequestIP, 0)
+	}
+	if body.Relations.Networks == nil {
+		body.Relations.Networks = make([]ServerCreateRequestNetwork, 0)
+	}
+	if body.Relations.IsoImages == nil {
+		body.Relations.IsoImages = make([]ServerCreateRequestIsoimage, 0)
+	}
+	if body.Relations.Storages == nil {
+		body.Relations.Storages = make([]ServerCreateRequestStorage, 0)
+	}
 	r := Request{
 		uri:    apiServerBase,
 		method: http.MethodPost,

--- a/server_test.go
+++ b/server_test.go
@@ -225,7 +225,7 @@ func TestClient_ShutdownServer(t *testing.T) {
 		assert.Equal(t, http.MethodPatch, request.Method)
 		power = false
 		writer.WriteHeader(http.StatusInternalServerError)
- 		writer.Write([]byte("☄ HTTP status code returned!"))
+		writer.Write([]byte("☄ HTTP status code returned!"))
 		fmt.Fprint(writer, "")
 	})
 


### PR DESCRIPTION
Somehow this field disappeared from our API docs. I found out that it is just an optional field. If it is set, all arrays of its sub-fields have to be filled with either empty "[]" or some elements. This means if one sub-field is filled and others are empty, those empty fields still have to be presented (with "[]" as values).