### PR TITLE
WIP: add consts for storage types

### DIFF
--- a/examples/storage.go
+++ b/examples/storage.go
@@ -31,6 +31,7 @@ func main() {
 		Capacity:     1,
 		LocationUUID: locationUUID,
 		Name:         "go-client-storage",
+		StorageType:  gsclient.StorageTypeHigh,
 	})
 	if err != nil {
 		log.Error("Create storage has failed with error", err)

--- a/storage.go
+++ b/storage.go
@@ -6,6 +6,12 @@ import (
 	"path"
 )
 
+const (
+	StorageTypeStandard = "standard"
+	StorageTypeHigh     = "high"
+	StorageTypeInsane   = "instane"
+)
+
 //StorageList JSON struct of a list of storages
 type StorageList struct {
 	List map[string]StorageProperties `json:"storages"`


### PR DESCRIPTION
This will allow users of gsclient-go to pass in just the const, instead
of having to look in our API docs for the proper string.