### PR TITLE
Add default API url constant

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ const (
 	version                        = "1.0.0"
 	resourceActiveStatus           = "active"
 	requestDoneStatus              = "done"
+	DefaultApiURL                  = "https://my.gridscale.io"
 )
 
 //Config config for client


### PR DESCRIPTION
Just a minor addition of a constant that contains the default API URL, enabling users to do:

```go
config := gsclient.NewConfiguration(gsclient.DefaultApiURL, userId, token, false)
```

*Wasn't sure if I should also add a CHANGELOG entry for this*