### PR TITLE
Retry network failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 2.2.0 (Unreleased)
 
 IMPROVEMENTS:
+* Retry requests in case of network issues (timeouts, connection resets, connection refused, etc)
+* Simple requests backoff in case of retrying errors
+* Increase defaultDelayIntervalMilliSecs to 1000 to reduce stress on API
 * Better variables/functions' names
 * Remove `LocationUUID` as objects' location depends on Project's location
 * Add gomod

--- a/common.go
+++ b/common.go
@@ -2,8 +2,10 @@ package gsclient
 
 import (
 	"errors"
-	"github.com/google/uuid"
 	"time"
+	"fmt"
+
+	"github.com/google/uuid"
 )
 
 //retryableFunc defines a function that can be retried
@@ -51,7 +53,7 @@ func retryWithLimitedNumOfRetries(targetFunc retryableFunc, numOfRetries int, de
 		retryNo++
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Maximum number of trials has been exhausted with error: %v", err)
 	}
-	return errors.New("timeout reached")
+	return errors.New("Maximum number of trials has been exhausted")
 }

--- a/common.go
+++ b/common.go
@@ -2,8 +2,8 @@ package gsclient
 
 import (
 	"errors"
-	"time"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -45,12 +45,13 @@ func retryWithLimitedNumOfRetries(targetFunc retryableFunc, numOfRetries int, de
 	var err error
 	var continueRetrying bool
 	for retryNo <= numOfRetries {
-		time.Sleep(delay) //delay between retries
+		retryNo++
+		time.Sleep(delay * time.Duration(retryNo)) //delay between retries
 		continueRetrying, err = targetFunc()
 		if !continueRetrying {
 			return err
 		}
-		retryNo++
+
 	}
 	if err != nil {
 		return fmt.Errorf("Maximum number of trials has been exhausted with error: %v", err)

--- a/config.go
+++ b/config.go
@@ -1,17 +1,18 @@
 package gsclient
 
 import (
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"os"
 	"runtime"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 const (
 	defaultCheckRequestTimeoutSecs = 120
 	defaultMaxNumberOfRetries      = 5
-	defaultDelayIntervalMilliSecs  = 500
+	defaultDelayIntervalMilliSecs  = 1000
 	version                        = "2.1.0"
 	defaultAPIURL                  = "https://api.gridscale.io"
 	resourceActiveStatus           = "active"

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/google/uuid v1.1.1
+	github.com/gridscale/gsclient-go v2.1.0+incompatible
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	github.com/google/uuid v1.1.1
-	github.com/gridscale/gsclient-go v2.1.0+incompatible
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 )

--- a/request.go
+++ b/request.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 )
 
@@ -97,6 +98,10 @@ func (r *request) execute(ctx context.Context, c Client, output interface{}) err
 		//execute the request
 		resp, err := httpClient.Do(request)
 		if err != nil {
+			if err, ok := err.(net.Error); ok {
+				logger.Debugf("Retrying request due to network error %v", err)
+				return true, err
+			}
 			logger.Errorf("Error while executing the request: %v", err)
 			//stop retrying (false) and return error
 			return false, err

--- a/request.go
+++ b/request.go
@@ -124,6 +124,7 @@ func (r *request) execute(ctx context.Context, c Client, output interface{}) err
 			if resp.StatusCode >= 500 || resp.StatusCode == 424 {
 				//retry (true) and accumulate error (in case that maximum number of retries is reached, and
 				//the latest error is still reported)
+				logger.Debugf("Retrying request: %v method sent to url %v with body %v", r.method, url, r.body)
 				return true, errorMessage
 			}
 			logger.Errorf(

--- a/request.go
+++ b/request.go
@@ -99,7 +99,7 @@ func (r *request) execute(ctx context.Context, c Client, output interface{}) err
 		resp, err := httpClient.Do(request)
 		if err != nil {
 			if err, ok := err.(net.Error); ok {
-				// excluse retry request with none GET method (write operations) in case of a request timeout
+				// exclude retry request with none GET method (write operations) in case of a request timeout
 				if err.Timeout() && r.method != http.MethodGet {
 					return false, err
 				}

--- a/request.go
+++ b/request.go
@@ -99,6 +99,10 @@ func (r *request) execute(ctx context.Context, c Client, output interface{}) err
 		resp, err := httpClient.Do(request)
 		if err != nil {
 			if err, ok := err.(net.Error); ok {
+				// excluse retry request with none GET method (write operations) in case of a request timeout
+				if err.Timeout() && r.method != http.MethodGet {
+					return false, err
+				}
 				logger.Debugf("Retrying request due to network error %v", err)
 				return true, err
 			}

--- a/request_test.go
+++ b/request_test.go
@@ -27,19 +27,19 @@ type apiTestCase struct {
 
 var getNetworkErrorTests = []networkTestCase{
 	{
-		name:          "rety the GET request in case of connection timeout",
+		name:          "retry the GET request in case of connection timeout",
 		apiURL:        "http://127.0.0.1",
 		httpClient:    &http.Client{Timeout: 1 * time.Nanosecond},
 		expectedError: "Maximum number of trials has been exhausted with error: Get %s%s: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)",
 	},
 	{
-		name:          "rety the GET request in case of connection refused",
+		name:          "retry the GET request in case of connection refused",
 		apiURL:        "http://127.0.0.1",
 		httpClient:    http.DefaultClient,
 		expectedError: "Maximum number of trials has been exhausted with error: Get %s%s: dial tcp 127.0.0.1:80: connect: connection refused",
 	},
 	{
-		name:          "rety the GET request in case of DNS lookup error",
+		name:          "retry the GET request in case of DNS lookup error",
 		apiURL:        "http://api.unkown.domain",
 		httpClient:    http.DefaultClient,
 		expectedError: "Maximum number of trials has been exhausted with error: Get %s%s: dial tcp: lookup api.unkown.domain: no such host",
@@ -48,19 +48,19 @@ var getNetworkErrorTests = []networkTestCase{
 
 var postNetworkErrorTests = []networkTestCase{
 	{
-		name:          "do not rety the POST request in case of connection timeout",
+		name:          "do not retry the POST request in case of connection timeout",
 		apiURL:        "http://127.0.0.1",
 		httpClient:    &http.Client{Timeout: 1 * time.Nanosecond},
 		expectedError: "Post %s%s: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)",
 	},
 	{
-		name:          "rety the POST request in case of connection refused",
+		name:          "retry the POST request in case of connection refused",
 		apiURL:        "http://127.0.0.1",
 		httpClient:    http.DefaultClient,
 		expectedError: "Maximum number of trials has been exhausted with error: Post %s%s: dial tcp 127.0.0.1:80: connect: connection refused",
 	},
 	{
-		name:          "rety the POST request in case of DNS lookup error",
+		name:          "retry the POST request in case of DNS lookup error",
 		apiURL:        "http://api.unkown.domain",
 		httpClient:    http.DefaultClient,
 		expectedError: "Maximum number of trials has been exhausted with error: Post %s%s: dial tcp: lookup api.unkown.domain: no such host",
@@ -69,20 +69,20 @@ var postNetworkErrorTests = []networkTestCase{
 
 var apiErrorTests = []apiTestCase{
 	{
-		name:          "rety the request in case of API error with status code 500",
+		name:          "retry the request in case of API error with status code 500",
 		statusCode:    500,
 		dummyUUID:     "690de890-13c0-4e76-8a01-e10ba8786e53",
 		expectedError: "Maximum number of trials has been exhausted with error: Status code: %d. Error: no error message received from server. Request UUID: %s. Please report this error along with the request UUID.",
 	},
 	{
-		name:          "rety the request in case of API error with status code 424",
+		name:          "retry the request in case of API error with status code 424",
 		statusCode:    424,
 		dummyUUID:     "690de890-13c0-4e76-8a01-e10ba8786e54",
 		expectedError: "Maximum number of trials has been exhausted with error: Status code: %d. Error: no error message received from server. Request UUID: %s. ",
 	},
 }
 
-func TestGetRequest_NetworkErrors(t *testing.T) {
+func TestRequestGet_NetworkErrors(t *testing.T) {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 	uri := path.Join(apiServerBase, dummyUUID)
@@ -98,7 +98,7 @@ func TestGetRequest_NetworkErrors(t *testing.T) {
 	}
 }
 
-func TestPostRequest_NetworkErrors(t *testing.T) {
+func TestRequestPost_NetworkErrors(t *testing.T) {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 	uri := apiServerBase
@@ -121,7 +121,7 @@ func TestPostRequest_NetworkErrors(t *testing.T) {
 	}
 }
 
-func TestGetRequest_API500and424Errors(t *testing.T) {
+func TestRequestGet_APIErrors(t *testing.T) {
 	server, client, mux := setupTestClient(true)
 	defer server.Close()
 	for _, test := range apiErrorTests {
@@ -136,7 +136,7 @@ func TestGetRequest_API500and424Errors(t *testing.T) {
 	}
 }
 
-func TestPatchRequest_API500and424Errors(t *testing.T) {
+func TestRequestPatch_APIErrors(t *testing.T) {
 	server, client, mux := setupTestClient(true)
 	defer server.Close()
 	for _, test := range apiErrorTests {

--- a/request_test.go
+++ b/request_test.go
@@ -63,7 +63,7 @@ var postNetworkErrorTests = []networkTestCase{
 		name:          "retry the POST request in case of DNS lookup error",
 		apiURL:        "http://api.unkown.domain",
 		httpClient:    http.DefaultClient,
-		expectedError: "Maximum number of trials has been exhausted with error: Post %s%s: dial tcp: lookup api.unkown.domain:",
+		expectedError: "Maximum number of trials has been exhausted with error: Post %s%s: dial tcp: lookup api.unkown.domain",
 	},
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -42,7 +42,7 @@ var getNetworkErrorTests = []networkTestCase{
 		name:          "retry the GET request in case of DNS lookup error",
 		apiURL:        "http://api.unkown.domain",
 		httpClient:    http.DefaultClient,
-		expectedError: "Maximum number of trials has been exhausted with error: Get %s%s: dial tcp: lookup api.unkown.domain: no such host",
+		expectedError: "Maximum number of trials has been exhausted with error: Get %s%s: dial tcp: lookup api.unkown.domain",
 	},
 }
 
@@ -63,7 +63,7 @@ var postNetworkErrorTests = []networkTestCase{
 		name:          "retry the POST request in case of DNS lookup error",
 		apiURL:        "http://api.unkown.domain",
 		httpClient:    http.DefaultClient,
-		expectedError: "Maximum number of trials has been exhausted with error: Post %s%s: dial tcp: lookup api.unkown.domain: no such host",
+		expectedError: "Maximum number of trials has been exhausted with error: Post %s%s: dial tcp: lookup api.unkown.domain:",
 	},
 }
 
@@ -72,7 +72,7 @@ var apiErrorTests = []apiTestCase{
 		name:          "retry the request in case of API error with status code 500",
 		statusCode:    500,
 		dummyUUID:     "690de890-13c0-4e76-8a01-e10ba8786e53",
-		expectedError: "Maximum number of trials has been exhausted with error: Status code: %d. Error: no error message received from server. Request UUID: %s. Please report this error along with the request UUID.",
+		expectedError: "Maximum number of trials has been exhausted with error: Status code: %d. Error: no error message received from server. Request UUID: %s.",
 	},
 	{
 		name:          "retry the request in case of API error with status code 424",
@@ -94,7 +94,7 @@ func TestRequestGet_NetworkErrors(t *testing.T) {
 		config.httpClient = test.httpClient
 		client := NewClient(config)
 		_, err := client.GetServer(emptyCtx, dummyUUID)
-		assert.EqualError(t, err, fmt.Sprintf(test.expectedError, config.apiURL, uri), test.name)
+		assert.Contains(t, fmt.Sprintf("%v", err), fmt.Sprintf(test.expectedError, config.apiURL, uri), test.name)
 	}
 }
 
@@ -116,7 +116,7 @@ func TestRequestPost_NetworkErrors(t *testing.T) {
 			HardwareProfile: DefaultServerHardware,
 			Labels:          []string{"label"},
 		})
-		assert.EqualError(t, err, fmt.Sprintf(test.expectedError, config.apiURL, uri), test.name)
+		assert.Contains(t, fmt.Sprintf("%v", err), fmt.Sprintf(test.expectedError, config.apiURL, uri), test.name)
 	}
 }
 
@@ -130,8 +130,7 @@ func TestRequestGet_APIErrors(t *testing.T) {
 			w.WriteHeader(test.statusCode)
 		})
 		_, err := client.GetServer(emptyCtx, test.dummyUUID)
-		fmt.Print(err)
-		assert.EqualError(t, err, fmt.Sprintf(test.expectedError, test.statusCode, dummyRequestUUID), test.name)
+		assert.Contains(t, fmt.Sprintf("%v", err), fmt.Sprintf(test.expectedError, test.statusCode, dummyRequestUUID), test.name)
 	}
 }
 
@@ -153,6 +152,6 @@ func TestRequestPatch_APIErrors(t *testing.T) {
 				Cores:  2,
 				Labels: nil,
 			})
-		assert.EqualError(t, err, fmt.Sprintf(test.expectedError, test.statusCode, dummyRequestUUID), test.name)
+		assert.Contains(t, fmt.Sprintf("%v", err), fmt.Sprintf(test.expectedError, test.statusCode, dummyRequestUUID), test.name)
 	}
 }

--- a/request_test.go
+++ b/request_test.go
@@ -18,39 +18,83 @@ type networkTestCase struct {
 	expectedError string
 }
 
-var networkErrorTests []networkTestCase = []networkTestCase{
+var getNetworkErrorTests []networkTestCase = []networkTestCase{
 	{
-		name: "Connection timeout",
-		apiURL: defaultAPIURL,
+		name: "rety the GET requet in case of connection timeout",
+		apiURL: "http://127.0.0.1",
 		httpClient: &http.Client{Timeout: 1 * time.Nanosecond},
-		expectedError: "Maximum number of trials has been exhausted with error: Get %s%s: net/http: request canceled (Client.Timeout exceeded while awaiting headers)",
+		expectedError: "Maximum number of trials has been exhausted with error: Get %s%s: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)",
 	},
 	{
-		name: "Connection refused",
+		name: "rety the GET requet in case of connection refused",
 		apiURL: "http://127.0.0.1",
 		httpClient: http.DefaultClient,
 		expectedError: "Maximum number of trials has been exhausted with error: Get %s%s: dial tcp 127.0.0.1:80: connect: connection refused",
 	},
 	{
-		name: "DNS lookup error",
+		name: "rety the GET requet in case of DNS lookup error",
 		apiURL: "http://api.unkown.domain",
 		httpClient: http.DefaultClient,
 		expectedError: "Maximum number of trials has been exhausted with error: Get %s%s: dial tcp: lookup api.unkown.domain: no such host",
 	},
 }
 
-func TestRequest_RetryNetworkErrors(t *testing.T) {
+var postNetworkErrorTests []networkTestCase = []networkTestCase{
+	{
+		name: "do not rety the POST requet in case of connection timeout",
+		apiURL: "http://127.0.0.1",
+		httpClient: &http.Client{Timeout: 1 * time.Nanosecond},
+		expectedError: "Post %s%s: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)",
+	},
+	{
+		name: "rety the POST requet in case of connection refused",
+		apiURL: "http://127.0.0.1",
+		httpClient: http.DefaultClient,
+		expectedError: "Maximum number of trials has been exhausted with error: Post %s%s: dial tcp 127.0.0.1:80: connect: connection refused",
+	},
+	{
+		name: "rety the POST requet in case of DNS lookup error",
+		apiURL: "http://api.unkown.domain",
+		httpClient: http.DefaultClient,
+		expectedError: "Maximum number of trials has been exhausted with error: Post %s%s: dial tcp: lookup api.unkown.domain: no such host",
+	},
+}
+
+func TestGetRequest_NetworkErrors(t *testing.T) {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 	uri := path.Join(apiServerBase, dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {})
 	defer server.Close()
 	
-	for _, test := range networkErrorTests {
+	for _, test := range getNetworkErrorTests {
 		config := NewConfiguration(test.apiURL, "uuid", "token", true, true, 1, 100, 5)
 		config.httpClient = test.httpClient
 		client := NewClient(config)
 		_, err := client.GetServer(emptyCtx, dummyUUID)
+		assert.EqualError(t, err, fmt.Sprintf(test.expectedError, config.apiURL, uri), test.name)
+	}
+}
+
+func TestPostRequest_NetworkErrors(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	uri := apiServerBase
+	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {})
+	defer server.Close()
+	
+	for _, test := range postNetworkErrorTests {
+		config := NewConfiguration(test.apiURL, "uuid", "token", true, true, 1, 100, 5)
+		config.httpClient = test.httpClient
+		client := NewClient(config)
+		_, err := client.CreateServer(emptyCtx, ServerCreateRequest{
+				Name:            "test",
+				Memory:          10,
+				Cores:           4,
+				LocationUUID:    dummyUUID,
+				HardwareProfile: DefaultServerHardware,
+				Labels:          []string{"label"},
+			})
 		assert.EqualError(t, err, fmt.Sprintf(test.expectedError, config.apiURL, uri), test.name)
 	}
 }

--- a/request_test.go
+++ b/request_test.go
@@ -1,0 +1,42 @@
+package gsclient
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type networkTestCase struct {
+	apiURL string
+	httpClient *http.Client
+	expectedError string
+}
+
+var networkErrorsConnectionTimeout []networkTestCase = []networkTestCase{
+	{
+		apiURL: defaultAPIURL,
+		httpClient: &http.Client{Timeout: 1 * time.Millisecond},
+		expectedError: "Maximum number of trials has been exhausted with error: Get %s%s: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)",
+	},
+}
+
+func TestRequest_RetryNetworkErrors(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	uri := path.Join(apiServerBase, dummyUUID)
+	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {})
+	defer server.Close()
+	
+	for _, test := range networkErrorsConnectionTimeout {
+		config := NewConfiguration(test.apiURL, "uuid", "token", true, true, 1, 100, 5)
+		config.httpClient = test.httpClient
+		client := NewClient(config)
+		_, err := client.GetServer(emptyCtx, dummyUUID)
+		assert.EqualError(t, err, fmt.Sprintf(test.expectedError, config.apiURL, uri))
+	}
+}

--- a/request_test.go
+++ b/request_test.go
@@ -12,17 +12,26 @@ import (
 )
 
 type networkTestCase struct {
+	name string
 	apiURL string
 	httpClient *http.Client
 	expectedError string
 }
 
-var networkErrorsConnectionTimeout []networkTestCase = []networkTestCase{
+var networkErrorTests []networkTestCase = []networkTestCase{
 	{
+		name: "Connection timeout",
 		apiURL: defaultAPIURL,
-		httpClient: &http.Client{Timeout: 1 * time.Millisecond},
-		expectedError: "Maximum number of trials has been exhausted with error: Get %s%s: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)",
+		httpClient: &http.Client{Timeout: 1 * time.Nanosecond},
+		expectedError: "Maximum number of trials has been exhausted with error: Get %s%s: net/http: request canceled (Client.Timeout exceeded while awaiting headers)",
 	},
+	{
+		name: "Connection refused",
+		apiURL: "http://127.0.0.1",
+		httpClient: http.DefaultClient,
+		expectedError: "Maximum number of trials has been exhausted with error: Get %s%s: dial tcp 127.0.0.1:80: connect: connection refused",
+	},
+	
 }
 
 func TestRequest_RetryNetworkErrors(t *testing.T) {
@@ -32,11 +41,11 @@ func TestRequest_RetryNetworkErrors(t *testing.T) {
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {})
 	defer server.Close()
 	
-	for _, test := range networkErrorsConnectionTimeout {
+	for _, test := range networkErrorTests {
 		config := NewConfiguration(test.apiURL, "uuid", "token", true, true, 1, 100, 5)
 		config.httpClient = test.httpClient
 		client := NewClient(config)
 		_, err := client.GetServer(emptyCtx, dummyUUID)
-		assert.EqualError(t, err, fmt.Sprintf(test.expectedError, config.apiURL, uri))
+		assert.EqualError(t, err, fmt.Sprintf(test.expectedError, config.apiURL, uri), test.name)
 	}
 }

--- a/request_test.go
+++ b/request_test.go
@@ -113,7 +113,6 @@ func TestRequestPost_NetworkErrors(t *testing.T) {
 			Name:            "test",
 			Memory:          10,
 			Cores:           4,
-			LocationUUID:    dummyUUID,
 			HardwareProfile: DefaultServerHardware,
 			Labels:          []string{"label"},
 		})

--- a/request_test.go
+++ b/request_test.go
@@ -31,7 +31,12 @@ var networkErrorTests []networkTestCase = []networkTestCase{
 		httpClient: http.DefaultClient,
 		expectedError: "Maximum number of trials has been exhausted with error: Get %s%s: dial tcp 127.0.0.1:80: connect: connection refused",
 	},
-	
+	{
+		name: "DNS lookup error",
+		apiURL: "http://api.unkown.domain",
+		httpClient: http.DefaultClient,
+		expectedError: "Maximum number of trials has been exhausted with error: Get %s%s: dial tcp: lookup api.unkown.domain: no such host",
+	},
 }
 
 func TestRequest_RetryNetworkErrors(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -329,8 +329,8 @@ func TestClient_ShutdownServer(t *testing.T) {
 					fmt.Fprint(writer, "")
 				})
 				err := client.ShutdownServer(emptyCtx, dummyUUID)
-				assert.EqualError(t, err,
-					fmt.Sprintf("Maximum number of trials has been exhausted with error: Status code: 500. Error: no error message received from server. Request UUID: %s. Please report this error along with the request UUID.",
+				assert.Contains(t, fmt.Sprintf("%v", err),
+					fmt.Sprintf("Maximum number of trials has been exhausted with error: Status code: 500. Error: no error message received from server. Request UUID: %s.",
 						dummyRequestUUID), "ShutdownServer returned an error with status code 500")
 				server.Close()
 			}

--- a/server_test.go
+++ b/server_test.go
@@ -329,7 +329,9 @@ func TestClient_ShutdownServer(t *testing.T) {
 					fmt.Fprint(writer, "")
 				})
 				err := client.ShutdownServer(emptyCtx, dummyUUID)
-				assert.Nil(t, err, "ShutdownServer returned an error %v", err)
+				assert.EqualError(t, err,
+					fmt.Sprintf("Maximum number of trials has been exhausted with error: Status code: 500. Error: no error message received from server. Request UUID: %s. Please report this error along with the request UUID.",
+						dummyRequestUUID), "ShutdownServer returned an error with status code 500")
 				server.Close()
 			}
 		}


### PR DESCRIPTION
provisioning k8s cluster depends mainly on gsclient-go/Terraform. Currently, gsclient-go only retries API errors with status code > 500 and 424.  However, provisioning k8s cluster sometimes fails due to network hiccup (conn resets and timeouts mostly).

so, we need to include the following issues to be handled by gs-client retry logic:
- networking issues (timeouts, conn resets, conn refused, etc) for read-only requests (e.g, GET)
- networking issues with connection refused to write requests (e.g, POST, PATCH, and DELETE )
- simple backoff request in case of retrying error.