### PR TITLE
Add `/v2` suffix in module path of `go.mod` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.2.1 (Unreleased)
+
+BUG FIXES:
+* (Hot fix) Fix incompatible major version when using gomod due to missing `/v2` suffix in module path of `go.mod` file 
+
 ## 2.2.0 (January 21, 2020)
 
 IMPROVEMENTS:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gridscale/gsclient-go
+module github.com/gridscale/gsclient-go/v2
 
 go 1.13
 


### PR DESCRIPTION
Fix incompatible major version when using gomod due to missing `/v2` suffix in module path of `go.mod` file