### PR TITLE
Deprecate labels create/delete options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.2.2 (Unreleased)
+
+DEPRECATED FEATURES:
+* Deprecate labels create/delete options
+
 ## 2.2.1 (January 21, 2020)
 
 BUG FIXES:

--- a/README.md
+++ b/README.md
@@ -266,8 +266,6 @@ Not all endpoints have been implemented in this client, but new ones will be add
     * Events Get (GetEventList)
 * Label
     * Labels Get (GetLabelList)
-    * Label Create (CreateLabel)
-    * Label Delete (DeleteLabel)
 * Location
     * Locations Get (GetLocationList)
     * Location Get (GetLocation)

--- a/examples/label.go
+++ b/examples/label.go
@@ -3,9 +3,10 @@ package main
 import (
 	"bufio"
 	"context"
+	"os"
+
 	"github.com/gridscale/gsclient-go"
 	log "github.com/sirupsen/logrus"
-	"os"
 )
 
 var emptyCtx = context.Background()
@@ -16,27 +17,6 @@ func main() {
 	config := gsclient.DefaultConfiguration(uuid, token)
 	client := gsclient.NewClient(config)
 	log.Info("gridscale client configured")
-
-	log.Info("Create label: Press 'Enter' to continue...")
-	bufio.NewReader(os.Stdin).ReadBytes('\n')
-
-	_, err := client.CreateLabel(
-		emptyCtx,
-		gsclient.LabelCreateRequest{
-			Label: "go-client-label",
-		})
-	if err != nil {
-		log.Error("Create label has failed with error", err)
-		return
-	}
-	log.Info("Label successfully created")
-	defer func() {
-		err := client.DeleteLabel(emptyCtx, "go-client-label")
-		if err != nil {
-			log.Error("Delete label has failed with error", err)
-			return
-		}
-	}()
 
 	log.Info("Retrieve labels: Press 'Enter' to continue...")
 	bufio.NewReader(os.Stdin).ReadBytes('\n')
@@ -49,7 +29,4 @@ func main() {
 	log.WithFields(log.Fields{
 		"labels": labels,
 	}).Info("Labels successfully retrieved")
-
-	log.Info("Delete label: Press 'Enter' to continue...")
-	bufio.NewReader(os.Stdin).ReadBytes('\n')
 }

--- a/label.go
+++ b/label.go
@@ -2,9 +2,7 @@ package gsclient
 
 import (
 	"context"
-	"errors"
 	"net/http"
-	"path"
 )
 
 //LabelList JSON struct of a list of labels
@@ -59,32 +57,4 @@ func (c *Client) GetLabelList(ctx context.Context) ([]Label, error) {
 		labels = append(labels, Label{Properties: properties})
 	}
 	return labels, err
-}
-
-//CreateLabel creates a new label
-//
-//See: https://gridscale.io/en//api-documentation/index.html#operation/CreateLabel
-func (c *Client) CreateLabel(ctx context.Context, body LabelCreateRequest) (CreateResponse, error) {
-	r := request{
-		uri:    apiLabelBase,
-		method: http.MethodPost,
-		body:   body,
-	}
-	var response CreateResponse
-	err := r.execute(ctx, *c, &response)
-	return response, err
-}
-
-//DeleteLabel deletes a label
-//
-//See: https://gridscale.io/en//api-documentation/index.html#operation/DeleteLabel
-func (c *Client) DeleteLabel(ctx context.Context, label string) error {
-	if label == "" {
-		return errors.New("'label' is required")
-	}
-	r := request{
-		uri:    path.Join(apiLabelBase, label),
-		method: http.MethodDelete,
-	}
-	return r.execute(ctx, *c, nil)
 }


### PR DESCRIPTION
We have a plan to remove these endpoints since you can create/remove labels by just attaching/detaching them to/from gridscale's resources.