### PR TITLE
`DEPRECATE` label's create/delete functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.2.1 (Unreleased)
+
+DEPRECATED FEATURES:
+* Deprecate labels create/delete options. 
+
 ## 2.2.1 (January 21, 2020)
 
 BUG FIXES:

--- a/README.md
+++ b/README.md
@@ -266,8 +266,8 @@ Not all endpoints have been implemented in this client, but new ones will be add
     * Events Get (GetEventList)
 * Label
     * Labels Get (GetLabelList)
-    * Label Create (CreateLabel)
-    * Label Delete (DeleteLabel)
+    * Label Create (CreateLabel) **DEPRECATED**
+    * Label Delete (DeleteLabel) **DEPRECATED**
 * Location
     * Locations Get (GetLocationList)
     * Location Get (GetLocation)

--- a/label.go
+++ b/label.go
@@ -61,7 +61,7 @@ func (c *Client) GetLabelList(ctx context.Context) ([]Label, error) {
 	return labels, err
 }
 
-//CreateLabel creates a new label
+//CreateLabel creates a new label (DEPRECATED)
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/CreateLabel
 func (c *Client) CreateLabel(ctx context.Context, body LabelCreateRequest) (CreateResponse, error) {
@@ -75,7 +75,7 @@ func (c *Client) CreateLabel(ctx context.Context, body LabelCreateRequest) (Crea
 	return response, err
 }
 
-//DeleteLabel deletes a label
+//DeleteLabel deletes a label (DEPRECATED)
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/DeleteLabel
 func (c *Client) DeleteLabel(ctx context.Context, label string) error {


### PR DESCRIPTION
Add a notice to README, and add comments to the code about deprecating label's create/delete functions.