### PR TITLE
remove label create/delete functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,6 @@ Not all endpoints have been implemented in this client, but new ones will be add
     * Events Get (GetEventList)
 * Label
     * Labels Get (GetLabelList)
-    * Label Create (CreateLabel) **DEPRECATED**
-    * Label Delete (DeleteLabel) **DEPRECATED**
 * Location
     * Locations Get (GetLocationList)
     * Location Get (GetLocation)

--- a/examples/label.go
+++ b/examples/label.go
@@ -3,9 +3,10 @@ package main
 import (
 	"bufio"
 	"context"
+	"os"
+
 	"github.com/gridscale/gsclient-go"
 	log "github.com/sirupsen/logrus"
-	"os"
 )
 
 var emptyCtx = context.Background()
@@ -16,27 +17,6 @@ func main() {
 	config := gsclient.DefaultConfiguration(uuid, token)
 	client := gsclient.NewClient(config)
 	log.Info("gridscale client configured")
-
-	log.Info("Create label: Press 'Enter' to continue...")
-	bufio.NewReader(os.Stdin).ReadBytes('\n')
-
-	_, err := client.CreateLabel(
-		emptyCtx,
-		gsclient.LabelCreateRequest{
-			Label: "go-client-label",
-		})
-	if err != nil {
-		log.Error("Create label has failed with error", err)
-		return
-	}
-	log.Info("Label successfully created")
-	defer func() {
-		err := client.DeleteLabel(emptyCtx, "go-client-label")
-		if err != nil {
-			log.Error("Delete label has failed with error", err)
-			return
-		}
-	}()
 
 	log.Info("Retrieve labels: Press 'Enter' to continue...")
 	bufio.NewReader(os.Stdin).ReadBytes('\n')
@@ -49,7 +29,4 @@ func main() {
 	log.WithFields(log.Fields{
 		"labels": labels,
 	}).Info("Labels successfully retrieved")
-
-	log.Info("Delete label: Press 'Enter' to continue...")
-	bufio.NewReader(os.Stdin).ReadBytes('\n')
 }

--- a/label.go
+++ b/label.go
@@ -2,9 +2,7 @@ package gsclient
 
 import (
 	"context"
-	"errors"
 	"net/http"
-	"path"
 )
 
 //LabelList JSON struct of a list of labels
@@ -59,32 +57,4 @@ func (c *Client) GetLabelList(ctx context.Context) ([]Label, error) {
 		labels = append(labels, Label{Properties: properties})
 	}
 	return labels, err
-}
-
-//CreateLabel creates a new label (DEPRECATED)
-//
-//See: https://gridscale.io/en//api-documentation/index.html#operation/CreateLabel
-func (c *Client) CreateLabel(ctx context.Context, body LabelCreateRequest) (CreateResponse, error) {
-	r := request{
-		uri:    apiLabelBase,
-		method: http.MethodPost,
-		body:   body,
-	}
-	var response CreateResponse
-	err := r.execute(ctx, *c, &response)
-	return response, err
-}
-
-//DeleteLabel deletes a label (DEPRECATED)
-//
-//See: https://gridscale.io/en//api-documentation/index.html#operation/DeleteLabel
-func (c *Client) DeleteLabel(ctx context.Context, label string) error {
-	if label == "" {
-		return errors.New("'label' is required")
-	}
-	r := request{
-		uri:    path.Join(apiLabelBase, label),
-		method: http.MethodDelete,
-	}
-	return r.execute(ctx, *c, nil)
 }

--- a/label_test.go
+++ b/label_test.go
@@ -3,10 +3,10 @@ package gsclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
-	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var labelTestCases = []uuidTestCase{
@@ -33,61 +33,6 @@ func TestClient_GetLabelList(t *testing.T) {
 	assert.Nil(t, err, "GetLabelList returned an error %v", err)
 	assert.Equal(t, 1, len(res))
 	assert.Equal(t, fmt.Sprintf("[%v]", getMockLabel("test")), fmt.Sprintf("%v", res))
-}
-
-func TestClient_CreateLabel(t *testing.T) {
-	server, client, mux := setupTestClient(true)
-	defer server.Close()
-	var isFailed bool
-	uri := apiLabelBase
-	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		assert.Equal(t, http.MethodPost, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
-		if isFailed {
-			writer.WriteHeader(400)
-		} else {
-			fmt.Fprint(writer, prepareLabelCreateResponse())
-		}
-	})
-	for _, test := range commonSuccessFailTestCases {
-		isFailed = test.isFailed
-		res, err := client.CreateLabel(
-			emptyCtx,
-			LabelCreateRequest{Label: "test"})
-		if test.isFailed {
-			assert.NotNil(t, err)
-		} else {
-			assert.Nil(t, err, "CreateLabel returned an error %v", err)
-			assert.Equal(t, fmt.Sprintf("%v", getMockLabelCreateResponse()), fmt.Sprintf("%v", res))
-		}
-	}
-}
-func TestClient_DeleteLabel(t *testing.T) {
-	server, client, mux := setupTestClient(true)
-	defer server.Close()
-	var isFailed bool
-	uri := path.Join(apiLabelBase, "test")
-	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		assert.Equal(t, http.MethodDelete, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
-		if isFailed {
-			writer.WriteHeader(400)
-		} else {
-			fmt.Fprint(writer, "")
-		}
-	})
-	for _, serverTest := range commonSuccessFailTestCases {
-		isFailed = serverTest.isFailed
-		for _, test := range labelTestCases {
-			err := client.DeleteLabel(emptyCtx, test.testUUID)
-			if test.isFailed || isFailed {
-				assert.NotNil(t, err)
-			} else {
-				assert.Nil(t, err, "DeleteLabel returned an error %v", err)
-			}
-		}
-	}
-
 }
 
 func getMockLabel(label string) Label {


### PR DESCRIPTION
Since we already deprecated label's create/delete functions, and they are already removed from gridscale's official API docs, this PR is to remove these functions from gridscale go SDK. I also updated the readme file.