### PR TITLE
Fix bug: "still retrying when the context is already expired"

### DIFF
--- a/request.go
+++ b/request.go
@@ -99,8 +99,11 @@ func (r *request) execute(ctx context.Context, c Client, output interface{}) err
 		resp, err := httpClient.Do(request)
 		if err != nil {
 			if err, ok := err.(net.Error); ok {
-				// exclude retry request with none GET method (write operations) in case of a request timeout
-				if err.Timeout() && r.method != http.MethodGet {
+				// exclude retry request with none GET method (write operations) in case of a request timeout or a context error
+				if (err.Timeout() || ctx.Err() != nil) && r.method != http.MethodGet {
+					if ctx.Err() != nil {
+						return false, ctx.Err()
+					}
 					return false, err
 				}
 				logger.Debugf("Retrying request due to network error %v", err)

--- a/request.go
+++ b/request.go
@@ -95,15 +95,23 @@ func (r *request) execute(ctx context.Context, c Client, output interface{}) err
 	var responseBodyBytes []byte
 	//
 	err = retryWithLimitedNumOfRetries(func() (bool, error) {
+		// no need to run when context is already expired
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		default:
+		}
 		//execute the request
 		resp, err := httpClient.Do(request)
 		if err != nil {
+			//If the error is caused by expired context, return context error and no need to retry
+			if ctx.Err() != nil {
+				return false, ctx.Err()
+			}
+
 			if err, ok := err.(net.Error); ok {
 				// exclude retry request with none GET method (write operations) in case of a request timeout or a context error
-				if (err.Timeout() || ctx.Err() != nil) && r.method != http.MethodGet {
-					if ctx.Err() != nil {
-						return false, ctx.Err()
-					}
+				if err.Timeout() && r.method != http.MethodGet {
 					return false, err
 				}
 				logger.Debugf("Retrying request due to network error %v", err)


### PR DESCRIPTION
When the context is expired, `execute` function is supposed to stop. In the previous version, I thought `err.Timeout()` would catch the deadline of the context (`execute` keeps retrying even if the context is done. It still returns the context error, but the context error becomes retryable error). The solution is to catch the context error early and also when the http request returns error (if the context is done, `httpClient.Do` also returns error). 