### PR TITLE
K8S support & fix some minor issues 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To be able to use the gridscale Go client in an application it can be imported i
 
 ```go
 import (
-	"github.com/gridscale/gsclient-go"
+	"github.com/gridscale/gsclient-go/v3"
 )
 ```
 

--- a/common.go
+++ b/common.go
@@ -9,6 +9,9 @@ import (
 	"github.com/google/uuid"
 )
 
+type emptyStruct struct {
+}
+
 //retryableFunc defines a function that can be retried
 type retryableFunc func() (bool, error)
 

--- a/examples/firewall.go
+++ b/examples/firewall.go
@@ -3,9 +3,10 @@ package main
 import (
 	"bufio"
 	"context"
-	"github.com/gridscale/gsclient-go"
-	log "github.com/sirupsen/logrus"
 	"os"
+
+	"github.com/gridscale/gsclient-go/v3"
+	log "github.com/sirupsen/logrus"
 )
 
 var emptyCtx = context.Background()

--- a/examples/ip.go
+++ b/examples/ip.go
@@ -3,9 +3,10 @@ package main
 import (
 	"bufio"
 	"context"
-	"github.com/gridscale/gsclient-go"
-	log "github.com/sirupsen/logrus"
 	"os"
+
+	"github.com/gridscale/gsclient-go/v3"
+	log "github.com/sirupsen/logrus"
 )
 
 var emptyCtx = context.Background()

--- a/examples/isoimage.go
+++ b/examples/isoimage.go
@@ -3,9 +3,10 @@ package main
 import (
 	"bufio"
 	"context"
-	"github.com/gridscale/gsclient-go"
-	"github.com/sirupsen/logrus"
 	"os"
+
+	"github.com/gridscale/gsclient-go/v3"
+	"github.com/sirupsen/logrus"
 )
 
 var emptyCtx = context.Background()

--- a/examples/label.go
+++ b/examples/label.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/gridscale/gsclient-go"
+	"github.com/gridscale/gsclient-go/v3"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/examples/loadbalancer.go
+++ b/examples/loadbalancer.go
@@ -3,9 +3,10 @@ package main
 import (
 	"bufio"
 	"context"
-	"github.com/gridscale/gsclient-go"
-	log "github.com/sirupsen/logrus"
 	"os"
+
+	"github.com/gridscale/gsclient-go/v3"
+	log "github.com/sirupsen/logrus"
 )
 
 var emptyCtx = context.Background()

--- a/examples/network.go
+++ b/examples/network.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/gridscale/gsclient-go"
+	"github.com/gridscale/gsclient-go/v3"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/examples/objectstorage.go
+++ b/examples/objectstorage.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/gridscale/gsclient-go"
+	"github.com/gridscale/gsclient-go/v3"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/examples/paas.go
+++ b/examples/paas.go
@@ -3,9 +3,10 @@ package main
 import (
 	"bufio"
 	"context"
-	"github.com/gridscale/gsclient-go"
-	log "github.com/sirupsen/logrus"
 	"os"
+
+	"github.com/gridscale/gsclient-go/v3"
+	log "github.com/sirupsen/logrus"
 )
 
 var emptyCtx = context.Background()

--- a/examples/server.go
+++ b/examples/server.go
@@ -8,7 +8,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/gridscale/gsclient-go"
+	"github.com/gridscale/gsclient-go/v3"
 )
 
 const webServerFirewallTemplateUUID = "82aa235b-61ba-48ca-8f47-7060a0435de7"

--- a/examples/snapshot.go
+++ b/examples/snapshot.go
@@ -3,10 +3,11 @@ package main
 import (
 	"bufio"
 	"context"
-	log "github.com/sirupsen/logrus"
 	"os"
 
-	"github.com/gridscale/gsclient-go"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/gridscale/gsclient-go/v3"
 )
 
 var emptyCtx = context.Background()

--- a/examples/snapshotschedule.go
+++ b/examples/snapshotschedule.go
@@ -3,10 +3,11 @@ package main
 import (
 	"bufio"
 	"context"
-	log "github.com/sirupsen/logrus"
 	"os"
 
-	"github.com/gridscale/gsclient-go"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/gridscale/gsclient-go/v3"
 )
 
 var emptyCtx = context.Background()

--- a/examples/sshkey.go
+++ b/examples/sshkey.go
@@ -3,9 +3,10 @@ package main
 import (
 	"bufio"
 	"context"
-	"github.com/gridscale/gsclient-go"
-	log "github.com/sirupsen/logrus"
 	"os"
+
+	"github.com/gridscale/gsclient-go/v3"
+	log "github.com/sirupsen/logrus"
 )
 
 var emptyCtx = context.Background()

--- a/examples/storage.go
+++ b/examples/storage.go
@@ -7,7 +7,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/gridscale/gsclient-go"
+	"github.com/gridscale/gsclient-go/v3"
 )
 
 var emptyCtx = context.Background()

--- a/examples/template.go
+++ b/examples/template.go
@@ -3,9 +3,10 @@ package main
 import (
 	"bufio"
 	"context"
-	"github.com/gridscale/gsclient-go"
-	log "github.com/sirupsen/logrus"
 	"os"
+
+	"github.com/gridscale/gsclient-go/v3"
+	log "github.com/sirupsen/logrus"
 )
 
 var emptyCtx = context.Background()

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	github.com/google/uuid v1.1.1
-	github.com/gridscale/gsclient-go v2.1.0+incompatible
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20200421231249-e086a090c8fd

--- a/paas.go
+++ b/paas.go
@@ -474,6 +474,7 @@ func (c *Client) RenewK8sCredentials(ctx context.Context, id string) error {
 	r := request{
 		uri:    path.Join(apiPaaSBase, "services", id, "renew_credentials"),
 		method: http.MethodPatch,
+		body:   emptyStruct{},
 	}
 	return r.execute(ctx, *c, nil)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2,8 +2,6 @@
 github.com/davecgh/go-spew/spew
 # github.com/google/uuid v1.1.1
 github.com/google/uuid
-# github.com/gridscale/gsclient-go v2.1.0+incompatible
-github.com/gridscale/gsclient-go
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/konsorten/go-windows-terminal-sequences
 # github.com/pmezard/go-difflib v1.0.0


### PR DESCRIPTION
This update is for gscloud.
- K8S support (get k8s config, renew k8s cluster's credentials).
- Replace wrong imported gsclient-go path `github.com/gridscale/gsclient-go` with `github.com/gridscale/gsclient-go/v3` in Readme and examples.