### PR TITLE
Support custom HTTP headers

### DIFF
--- a/client.go
+++ b/client.go
@@ -88,6 +88,12 @@ func (c *Client) APIToken() string {
 	return c.cfg.apiToken
 }
 
+//WithHTTPHeaders adds custom HTTP headers to Client
+func (c *Client) WithHTTPHeaders(headers map[string]string) *Client {
+	c.cfg.httpHeaders = headers
+	return c
+}
+
 //waitForRequestCompleted allows to wait for a request to complete
 func (c *Client) waitForRequestCompleted(ctx context.Context, id string) error {
 	if !isValidUUID(id) {

--- a/client.go
+++ b/client.go
@@ -89,9 +89,8 @@ func (c *Client) APIToken() string {
 }
 
 //WithHTTPHeaders adds custom HTTP headers to Client
-func (c *Client) WithHTTPHeaders(headers map[string]string) *Client {
+func (c *Client) WithHTTPHeaders(headers map[string]string) {
 	c.cfg.httpHeaders = headers
-	return c
 }
 
 //waitForRequestCompleted allows to wait for a request to complete

--- a/client_test.go
+++ b/client_test.go
@@ -52,3 +52,11 @@ func TestClient_waitForRequestCompleted(t *testing.T) {
 		}
 	}
 }
+func TestClient_WithHeaders(t *testing.T) {
+	config := DefaultConfiguration(dummyUUID, "token")
+	client := NewClient(config)
+	client = client.WithHTTPHeaders(map[string]string{
+		"test_header": "test_header_value",
+	})
+	assert.Equal(t, client.cfg.httpHeaders["test_header"], "test_header_value")
+}

--- a/client_test.go
+++ b/client_test.go
@@ -55,7 +55,7 @@ func TestClient_waitForRequestCompleted(t *testing.T) {
 func TestClient_WithHeaders(t *testing.T) {
 	config := DefaultConfiguration(dummyUUID, "token")
 	client := NewClient(config)
-	client = client.WithHTTPHeaders(map[string]string{
+	client.WithHTTPHeaders(map[string]string{
 		"test_header": "test_header_value",
 	})
 	assert.Equal(t, client.cfg.httpHeaders["test_header"], "test_header_value")

--- a/config.go
+++ b/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	userUUID           string
 	apiToken           string
 	userAgent          string
+	httpHeaders        map[string]string
 	sync               bool
 	httpClient         *http.Client
 	delayInterval      time.Duration

--- a/request.go
+++ b/request.go
@@ -87,6 +87,13 @@ func (r *request) execute(ctx context.Context, c Client, output interface{}) err
 	request.Header.Add("X-Auth-UserID", c.UserUUID())
 	request.Header.Add("X-Auth-Token", c.APIToken())
 	request.Header.Add("Content-Type", bodyType)
+
+	//Set headers based on a given list of custom headers
+	//Use Header.Set() instead of Header.Add() because we want to
+	//override the headers' values if they are already set.
+	for k, v := range c.cfg.httpHeaders {
+		request.Header.Set(k, v)
+	}
 	logger.Debugf("Request body: %v", request.Body)
 	logger.Debugf("Request headers: %v", request.Header)
 

--- a/request.go
+++ b/request.go
@@ -84,9 +84,9 @@ func (r *request) execute(ctx context.Context, c Client, output interface{}) err
 	}
 	request = request.WithContext(ctx)
 	request.Header.Set("User-Agent", c.UserAgent())
-	request.Header.Add("X-Auth-UserID", c.UserUUID())
-	request.Header.Add("X-Auth-Token", c.APIToken())
-	request.Header.Add("Content-Type", bodyType)
+	request.Header.Set("X-Auth-UserID", c.UserUUID())
+	request.Header.Set("X-Auth-Token", c.APIToken())
+	request.Header.Set("Content-Type", bodyType)
 
 	//Set headers based on a given list of custom headers
 	//Use Header.Set() instead of Header.Add() because we want to


### PR DESCRIPTION
- Custom HTTP headers can be attached via `client.WithHTTPHeaders(map[string]string)` function.
- Existing HTTP headers can be replaced via `client.WithHTTPHeaders(map[string]string)` function by inputting the headers' name and their new values. E.g: 
`client.WithHTTPHeaders(map[string]string{
		"User-Agent": "Example-User-Agent"",
})`
- Use `Header.Set()` instead of `Header.Add()` since we don't want to append values to an existing header.

Fixes #124