### PR TITLE
Dealing with rate limit

### DIFF
--- a/client.go
+++ b/client.go
@@ -99,7 +99,7 @@ func (c *Client) waitForRequestCompleted(ctx context.Context, id string) error {
 		return errors.New("'id' is invalid")
 	}
 	return retryWithContext(ctx, func() (bool, error) {
-		r := request{
+		r := gsRequest{
 			uri:                 path.Join(requestBase, id),
 			method:              "GET",
 			skipCheckingRequest: true,

--- a/client.go
+++ b/client.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"path"
 	"time"
-
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -41,11 +39,6 @@ func NewClient(c *Config) *Client {
 		cfg: c,
 	}
 	return client
-}
-
-//Logger returns logger
-func (c *Client) Logger() logrus.Logger {
-	return c.cfg.logger
 }
 
 //HttpClient returns http client

--- a/config.go
+++ b/config.go
@@ -31,7 +31,15 @@ type Config struct {
 	httpClient         *http.Client
 	delayInterval      time.Duration
 	maxNumberOfRetries int
-	logger             logrus.Logger
+}
+
+var logger = logrus.Logger{
+	Out:   os.Stderr,
+	Level: logrus.InfoLevel,
+	Formatter: &logrus.TextFormatter{
+		FullTimestamp: true,
+		DisableColors: false,
+	},
 }
 
 //NewConfiguration creates a new config
@@ -47,18 +55,8 @@ type Config struct {
 //		+ maxNumberOfRetries int: number of retries when server returns 5xx, 424 error code.
 func NewConfiguration(apiURL string, uuid string, token string, debugMode, sync bool,
 	delayIntervalMilliSecs, maxNumberOfRetries int) *Config {
-	logLevel := logrus.InfoLevel
 	if debugMode {
-		logLevel = logrus.DebugLevel
-	}
-
-	logger := logrus.Logger{
-		Out:   os.Stderr,
-		Level: logLevel,
-		Formatter: &logrus.TextFormatter{
-			FullTimestamp: true,
-			DisableColors: false,
-		},
+		logger.Level = logrus.DebugLevel
 	}
 
 	cfg := &Config{
@@ -68,7 +66,6 @@ func NewConfiguration(apiURL string, uuid string, token string, debugMode, sync 
 		userAgent:          "gsclient-go/" + version + " (" + runtime.GOOS + ")",
 		sync:               sync,
 		httpClient:         http.DefaultClient,
-		logger:             logger,
 		delayInterval:      time.Duration(delayIntervalMilliSecs) * time.Millisecond,
 		maxNumberOfRetries: maxNumberOfRetries,
 	}
@@ -77,14 +74,6 @@ func NewConfiguration(apiURL string, uuid string, token string, debugMode, sync 
 
 //DefaultConfiguration creates a default configuration
 func DefaultConfiguration(uuid string, token string) *Config {
-	logger := logrus.Logger{
-		Out:   os.Stderr,
-		Level: logrus.InfoLevel,
-		Formatter: &logrus.TextFormatter{
-			FullTimestamp: true,
-			DisableColors: false,
-		},
-	}
 	cfg := &Config{
 		apiURL:             defaultAPIURL,
 		userUUID:           uuid,
@@ -92,7 +81,6 @@ func DefaultConfiguration(uuid string, token string) *Config {
 		userAgent:          "gsclient-go/" + version + " (" + runtime.GOOS + ")",
 		sync:               true,
 		httpClient:         http.DefaultClient,
-		logger:             logger,
 		delayInterval:      time.Duration(defaultDelayIntervalMilliSecs) * time.Millisecond,
 		maxNumberOfRetries: defaultMaxNumberOfRetries,
 	}

--- a/event.go
+++ b/event.go
@@ -51,7 +51,7 @@ type EventProperties struct {
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/EventGetAll
 func (c *Client) GetEventList(ctx context.Context) ([]Event, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 apiEventBase,
 		method:              http.MethodGet,
 		skipCheckingRequest: true,

--- a/firewall.go
+++ b/firewall.go
@@ -168,7 +168,7 @@ var (
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getFirewalls
 func (c *Client) GetFirewallList(ctx context.Context) ([]Firewall, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiFirewallBase),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -189,7 +189,7 @@ func (c *Client) GetFirewall(ctx context.Context, id string) (Firewall, error) {
 	if !isValidUUID(id) {
 		return Firewall{}, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiFirewallBase, id),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -203,7 +203,7 @@ func (c *Client) GetFirewall(ctx context.Context, id string) (Firewall, error) {
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/createFirewall
 func (c *Client) CreateFirewall(ctx context.Context, body FirewallCreateRequest) (FirewallCreateResponse, error) {
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiFirewallBase),
 		method: http.MethodPost,
 		body:   body,
@@ -220,7 +220,7 @@ func (c *Client) UpdateFirewall(ctx context.Context, id string, body FirewallUpd
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiFirewallBase, id),
 		method: http.MethodPatch,
 		body:   body,
@@ -235,7 +235,7 @@ func (c *Client) DeleteFirewall(ctx context.Context, id string) error {
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiFirewallBase, id),
 		method: http.MethodDelete,
 	}
@@ -249,7 +249,7 @@ func (c *Client) GetFirewallEventList(ctx context.Context, id string) ([]Event, 
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiFirewallBase, id, "events"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,

--- a/ip.go
+++ b/ip.go
@@ -185,7 +185,7 @@ func (c *Client) GetIP(ctx context.Context, id string) (IP, error) {
 	if !isValidUUID(id) {
 		return IP{}, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiIPBase, id),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -201,7 +201,7 @@ func (c *Client) GetIP(ctx context.Context, id string) (IP, error) {
 //
 //https://gridscale.io/en//api-documentation/index.html#operation/getIps
 func (c *Client) GetIPList(ctx context.Context) ([]IP, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 apiIPBase,
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -223,7 +223,7 @@ func (c *Client) GetIPList(ctx context.Context) ([]IP, error) {
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/createIp
 func (c *Client) CreateIP(ctx context.Context, body IPCreateRequest) (IPCreateResponse, error) {
-	r := request{
+	r := gsRequest{
 		uri:    apiIPBase,
 		method: http.MethodPost,
 		body:   body,
@@ -241,7 +241,7 @@ func (c *Client) DeleteIP(ctx context.Context, id string) error {
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiIPBase, id),
 		method: http.MethodDelete,
 	}
@@ -255,7 +255,7 @@ func (c *Client) UpdateIP(ctx context.Context, id string, body IPUpdateRequest) 
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiIPBase, id),
 		method: http.MethodPatch,
 		body:   body,
@@ -270,7 +270,7 @@ func (c *Client) GetIPEventList(ctx context.Context, id string) ([]Event, error)
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiIPBase, id, "events"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -300,7 +300,7 @@ func (c *Client) GetIPsByLocation(ctx context.Context, id string) ([]IP, error) 
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiLocationBase, id, "ips"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -318,7 +318,7 @@ func (c *Client) GetIPsByLocation(ctx context.Context, id string) ([]IP, error) 
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getDeletedIps
 func (c *Client) GetDeletedIPs(ctx context.Context) ([]IP, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiDeletedBase, "ips"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,

--- a/isoimage.go
+++ b/isoimage.go
@@ -137,7 +137,7 @@ type ISOImageUpdateRequest struct {
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getIsoimages
 func (c *Client) GetISOImageList(ctx context.Context) ([]ISOImage, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiISOBase),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -158,7 +158,7 @@ func (c *Client) GetISOImage(ctx context.Context, id string) (ISOImage, error) {
 	if !isValidUUID(id) {
 		return ISOImage{}, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiISOBase, id),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -172,7 +172,7 @@ func (c *Client) GetISOImage(ctx context.Context, id string) (ISOImage, error) {
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/createIsoimage
 func (c *Client) CreateISOImage(ctx context.Context, body ISOImageCreateRequest) (ISOImageCreateResponse, error) {
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiISOBase),
 		method: http.MethodPost,
 		body:   body,
@@ -189,7 +189,7 @@ func (c *Client) UpdateISOImage(ctx context.Context, id string, body ISOImageUpd
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiISOBase, id),
 		method: http.MethodPatch,
 		body:   body,
@@ -204,7 +204,7 @@ func (c *Client) DeleteISOImage(ctx context.Context, id string) error {
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiISOBase, id),
 		method: http.MethodDelete,
 	}
@@ -218,7 +218,7 @@ func (c *Client) GetISOImageEventList(ctx context.Context, id string) ([]Event, 
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiISOBase, id, "events"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -239,7 +239,7 @@ func (c *Client) GetISOImagesByLocation(ctx context.Context, id string) ([]ISOIm
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiLocationBase, id, "isoimages"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -257,7 +257,7 @@ func (c *Client) GetISOImagesByLocation(ctx context.Context, id string) ([]ISOIm
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getDeletedIsoimages
 func (c *Client) GetDeletedISOImages(ctx context.Context) ([]ISOImage, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiDeletedBase, "isoimages"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,

--- a/label.go
+++ b/label.go
@@ -45,7 +45,7 @@ type LabelCreateRequest struct {
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/GetLabels
 func (c *Client) GetLabelList(ctx context.Context) ([]Label, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 apiLabelBase,
 		method:              http.MethodGet,
 		skipCheckingRequest: true,

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -182,7 +182,7 @@ var (
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getLoadbalancers
 func (c *Client) GetLoadBalancerList(ctx context.Context) ([]LoadBalancer, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 apiLoadBalancerBase,
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -203,7 +203,7 @@ func (c *Client) GetLoadBalancer(ctx context.Context, id string) (LoadBalancer, 
 	if !isValidUUID(id) {
 		return LoadBalancer{}, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiLoadBalancerBase, id),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -222,7 +222,7 @@ func (c *Client) CreateLoadBalancer(ctx context.Context, body LoadBalancerCreate
 	if body.Labels == nil {
 		body.Labels = make([]string, 0)
 	}
-	r := request{
+	r := gsRequest{
 		uri:    apiLoadBalancerBase,
 		method: http.MethodPost,
 		body:   body,
@@ -244,7 +244,7 @@ func (c *Client) UpdateLoadBalancer(ctx context.Context, id string, body LoadBal
 	if body.Labels == nil {
 		body.Labels = make([]string, 0)
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiLoadBalancerBase, id),
 		method: http.MethodPatch,
 		body:   body,
@@ -259,7 +259,7 @@ func (c *Client) GetLoadBalancerEventList(ctx context.Context, id string) ([]Eve
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiLoadBalancerBase, id, "events"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -280,7 +280,7 @@ func (c *Client) DeleteLoadBalancer(ctx context.Context, id string) error {
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiLoadBalancerBase, id),
 		method: http.MethodDelete,
 	}

--- a/location.go
+++ b/location.go
@@ -44,7 +44,7 @@ type LocationProperties struct {
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getLocations
 func (c *Client) GetLocationList(ctx context.Context) ([]Location, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 apiLocationBase,
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -65,7 +65,7 @@ func (c *Client) GetLocation(ctx context.Context, id string) (Location, error) {
 	if !isValidUUID(id) {
 		return Location{}, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiLocationBase, id),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,

--- a/network.go
+++ b/network.go
@@ -181,7 +181,7 @@ func (c *Client) GetNetwork(ctx context.Context, id string) (Network, error) {
 	if !isValidUUID(id) {
 		return Network{}, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiNetworkBase, id),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -195,7 +195,7 @@ func (c *Client) GetNetwork(ctx context.Context, id string) (Network, error) {
 //
 //See: https://gridscale.io/en//api-documentation/index.html#tag/network
 func (c *Client) CreateNetwork(ctx context.Context, body NetworkCreateRequest) (NetworkCreateResponse, error) {
-	r := request{
+	r := gsRequest{
 		uri:    apiNetworkBase,
 		method: http.MethodPost,
 		body:   body,
@@ -212,7 +212,7 @@ func (c *Client) DeleteNetwork(ctx context.Context, id string) error {
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiNetworkBase, id),
 		method: http.MethodDelete,
 	}
@@ -226,7 +226,7 @@ func (c *Client) UpdateNetwork(ctx context.Context, id string, body NetworkUpdat
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiNetworkBase, id),
 		method: http.MethodPatch,
 		body:   body,
@@ -238,7 +238,7 @@ func (c *Client) UpdateNetwork(ctx context.Context, id string, body NetworkUpdat
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getNetworks
 func (c *Client) GetNetworkList(ctx context.Context) ([]Network, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 apiNetworkBase,
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -261,7 +261,7 @@ func (c *Client) GetNetworkEventList(ctx context.Context, id string) ([]Event, e
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiNetworkBase, id, "events"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -296,7 +296,7 @@ func (c *Client) GetNetworksByLocation(ctx context.Context, id string) ([]Networ
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiLocationBase, id, "networks"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -314,7 +314,7 @@ func (c *Client) GetNetworksByLocation(ctx context.Context, id string) ([]Networ
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getDeletedNetworks
 func (c *Client) GetDeletedNetworks(ctx context.Context) ([]Network, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiDeletedBase, "networks"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,

--- a/objectstorage.go
+++ b/objectstorage.go
@@ -77,7 +77,7 @@ type ObjectStorageBucketProperties struct {
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getAccessKeys
 func (c *Client) GetObjectStorageAccessKeyList(ctx context.Context) ([]ObjectStorageAccessKey, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiObjectStorageBase, "access_keys"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -98,7 +98,7 @@ func (c *Client) GetObjectStorageAccessKey(ctx context.Context, id string) (Obje
 	if strings.TrimSpace(id) == "" {
 		return ObjectStorageAccessKey{}, errors.New("'id' is required")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiObjectStorageBase, "access_keys", id),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -112,7 +112,7 @@ func (c *Client) GetObjectStorageAccessKey(ctx context.Context, id string) (Obje
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/createAccessKey
 func (c *Client) CreateObjectStorageAccessKey(ctx context.Context) (ObjectStorageAccessKeyCreateResponse, error) {
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiObjectStorageBase, "access_keys"),
 		method: http.MethodPost,
 	}
@@ -128,7 +128,7 @@ func (c *Client) DeleteObjectStorageAccessKey(ctx context.Context, id string) er
 	if strings.TrimSpace(id) == "" {
 		return errors.New("'id' is required")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiObjectStorageBase, "access_keys", id),
 		method: http.MethodDelete,
 	}
@@ -139,7 +139,7 @@ func (c *Client) DeleteObjectStorageAccessKey(ctx context.Context, id string) er
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getBuckets
 func (c *Client) GetObjectStorageBucketList(ctx context.Context) ([]ObjectStorageBucket, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiObjectStorageBase, "buckets"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,

--- a/paas.go
+++ b/paas.go
@@ -364,7 +364,7 @@ type PaaSSecurityZoneUpdateRequest struct {
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getPaasServices
 func (c *Client) GetPaaSServiceList(ctx context.Context) ([]PaaSService, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiPaaSBase, "services"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -384,7 +384,7 @@ func (c *Client) GetPaaSServiceList(ctx context.Context) ([]PaaSService, error) 
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/createPaasService
 func (c *Client) CreatePaaSService(ctx context.Context, body PaaSServiceCreateRequest) (PaaSServiceCreateResponse, error) {
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiPaaSBase, "services"),
 		method: http.MethodPost,
 		body:   body,
@@ -401,7 +401,7 @@ func (c *Client) GetPaaSService(ctx context.Context, id string) (PaaSService, er
 	if !isValidUUID(id) {
 		return PaaSService{}, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiPaaSBase, "services", id),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -418,7 +418,7 @@ func (c *Client) UpdatePaaSService(ctx context.Context, id string, body PaaSServ
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiPaaSBase, "services", id),
 		method: http.MethodPatch,
 		body:   body,
@@ -433,7 +433,7 @@ func (c *Client) DeletePaaSService(ctx context.Context, id string) error {
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiPaaSBase, "services", id),
 		method: http.MethodDelete,
 	}
@@ -447,7 +447,7 @@ func (c *Client) GetPaaSServiceMetrics(ctx context.Context, id string) ([]PaaSSe
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiPaaSBase, "services", id, "metrics"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -471,7 +471,7 @@ func (c *Client) RenewK8sCredentials(ctx context.Context, id string) error {
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiPaaSBase, "services", id, "renew_credentials"),
 		method: http.MethodPatch,
 		body:   emptyStruct{},
@@ -483,7 +483,7 @@ func (c *Client) RenewK8sCredentials(ctx context.Context, id string) error {
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getPaasServiceTemplates
 func (c *Client) GetPaaSTemplateList(ctx context.Context) ([]PaaSTemplate, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiPaaSBase, "service_templates"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -504,7 +504,7 @@ func (c *Client) GetPaaSTemplateList(ctx context.Context) ([]PaaSTemplate, error
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getPaasSecurityZones
 func (c *Client) GetPaaSSecurityZoneList(ctx context.Context) ([]PaaSSecurityZone, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiPaaSBase, "security_zones"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -524,7 +524,7 @@ func (c *Client) GetPaaSSecurityZoneList(ctx context.Context) ([]PaaSSecurityZon
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/createPaasSecurityZone
 func (c *Client) CreatePaaSSecurityZone(ctx context.Context, body PaaSSecurityZoneCreateRequest) (PaaSSecurityZoneCreateResponse, error) {
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiPaaSBase, "security_zones"),
 		method: http.MethodPost,
 		body:   body,
@@ -541,7 +541,7 @@ func (c *Client) GetPaaSSecurityZone(ctx context.Context, id string) (PaaSSecuri
 	if !isValidUUID(id) {
 		return PaaSSecurityZone{}, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiPaaSBase, "security_zones", id),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -558,7 +558,7 @@ func (c *Client) UpdatePaaSSecurityZone(ctx context.Context, id string, body Paa
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiPaaSBase, "security_zones", id),
 		method: http.MethodPatch,
 		body:   body,
@@ -573,7 +573,7 @@ func (c *Client) DeletePaaSSecurityZone(ctx context.Context, id string) error {
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiPaaSBase, "security_zones", id),
 		method: http.MethodDelete,
 	}
@@ -584,7 +584,7 @@ func (c *Client) DeletePaaSSecurityZone(ctx context.Context, id string) error {
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getDeletedPaasServices
 func (c *Client) GetDeletedPaaSServices(ctx context.Context) ([]PaaSService, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiDeletedBase, "paas_services"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,

--- a/request.go
+++ b/request.go
@@ -182,7 +182,7 @@ func (r *gsRequest) retryHTTPRequest(ctx context.Context, c Client, httpReq *htt
 			return false, err
 		}
 
-		logger.Debugf("Status code: %v. Request UUID: %v.", statusCode, requestUUID)
+		logger.Debugf("Status code: %v. Request UUID: %v. Headers: %v", statusCode, requestUUID, resp.Header)
 
 		if statusCode >= 300 {
 			var errorMessage RequestError //error messages have a different structure, so they are read with a different struct

--- a/request.go
+++ b/request.go
@@ -184,13 +184,13 @@ func (r *gsRequest) retryHTTPRequest(ctx context.Context, c Client, httpReq *htt
 
 		logger.Debugf("Status code: %v. Request UUID: %v.", statusCode, requestUUID)
 
-		if resp.StatusCode >= 300 {
+		if statusCode >= 300 {
 			var errorMessage RequestError //error messages have a different structure, so they are read with a different struct
 			errorMessage.StatusCode = statusCode
 			errorMessage.RequestUUID = requestUUID
 			json.Unmarshal(responseBodyBytes, &errorMessage)
 			//if internal server error OR object is in status that does not allow the request, retry
-			if resp.StatusCode >= 500 || resp.StatusCode == 424 {
+			if statusCode >= 500 || statusCode == 424 {
 				//retry (true) and accumulate error (in case that maximum number of retries is reached, and
 				//the latest error is still reported)
 				logger.Debugf("Retrying request: %v method sent to url %v with body %v", r.method, httpReq.URL.RequestURI(), r.body)
@@ -198,7 +198,7 @@ func (r *gsRequest) retryHTTPRequest(ctx context.Context, c Client, httpReq *htt
 			}
 
 			//If status code is 429, that means we reach the rate limit
-			if resp.StatusCode == 429 {
+			if statusCode == 429 {
 				//Get the time that the rate limit will be reset
 				rateLimitResetTimestamp := resp.Header.Get(requestRateLimitResetHeaderParam)
 				//Get the delay time

--- a/request.go
+++ b/request.go
@@ -201,7 +201,7 @@ func (r *gsRequest) retryHTTPRequest(
 						return false, err
 					}
 					//Delay the retry until the rate limit is reset
-					logger.Debugf("Delay request for %d ms: %v method sent to url %v with body %v", delayMs, r.method, httpReq.URL.RequestURI(), r.body)
+					logger.Debugf("Delay request for %d ms: %v method sent to url %v with body %v. ratelimit-reset: %v", delayMs, r.method, httpReq.URL.RequestURI(), r.body, rateLimitResetTimestamp)
 					time.Sleep(time.Duration(delayMs) * time.Millisecond)
 				}
 				logger.Debugf("Retrying request: %v method sent to url %v with body %v", r.method, httpReq.URL.RequestURI(), r.body)

--- a/request.go
+++ b/request.go
@@ -69,7 +69,6 @@ const (
 //This function takes the client and a struct and then adds the result to the given struct if possible
 func (r *gsRequest) execute(ctx context.Context, c Client, output interface{}) error {
 	url := c.cfg.apiURL + r.uri
-	logger := c.Logger()
 	logger.Debugf("Preparing %v request sent to URL: %v", r.method, url)
 
 	//Prepare http request (including HTTP headers preparation, etc.)
@@ -136,7 +135,6 @@ func (r *gsRequest) prepareHTTPRequest(ctx context.Context, url string, cfg *Con
 //retryHTTPRequest runs & retries a HTTP request
 //returns UUID (string), response body ([]byte), error
 func (r *gsRequest) retryHTTPRequest(ctx context.Context, c Client, httpReq *http.Request) (string, []byte, error) {
-	logger := c.Logger()
 	httpClient := c.HttpClient()
 	//Init request UUID variable
 	var requestUUID string

--- a/request.go
+++ b/request.go
@@ -95,6 +95,7 @@ func (r *gsRequest) execute(ctx context.Context, c Client, output interface{}) e
 	return nil
 }
 
+//prepareHTTPRequest prepares a http request
 func (r *gsRequest) prepareHTTPRequest(ctx context.Context, url string, cfg *Config) (*http.Request, error) {
 	//Convert the body of the request to json
 	jsonBody := new(bytes.Buffer)
@@ -126,6 +127,8 @@ func (r *gsRequest) prepareHTTPRequest(ctx context.Context, url string, cfg *Con
 	return request, nil
 }
 
+//retryHTTPRequest runs & retries a HTTP request
+//returns UUID (string), response body ([]byte), error
 func (r *gsRequest) retryHTTPRequest(ctx context.Context, c Client, httpReq *http.Request) (string, []byte, error) {
 	logger := c.Logger()
 	httpClient := c.HttpClient()

--- a/request.go
+++ b/request.go
@@ -201,7 +201,7 @@ func (r *gsRequest) retryHTTPRequest(
 						return false, err
 					}
 					//Delay the retry until the rate limit is reset
-					logger.Debugf("Delay request for %d ms: %v method sent to url %v with body %v. ratelimit-reset: %v", delayMs, r.method, httpReq.URL.RequestURI(), r.body, rateLimitResetTimestamp)
+					logger.Debugf("Delay request for %d ms: %v method sent to url %v with body %v", delayMs, r.method, httpReq.URL.RequestURI(), r.body)
 					time.Sleep(time.Duration(delayMs) * time.Millisecond)
 				}
 				logger.Debugf("Retrying request: %v method sent to url %v with body %v", r.method, httpReq.URL.RequestURI(), r.body)

--- a/request.go
+++ b/request.go
@@ -68,11 +68,9 @@ const (
 
 //This function takes the client and a struct and then adds the result to the given struct if possible
 func (r *gsRequest) execute(ctx context.Context, c Client, output interface{}) error {
-	url := c.cfg.apiURL + r.uri
-	logger.Debugf("Preparing %v request sent to URL: %v", r.method, url)
 
 	//Prepare http request (including HTTP headers preparation, etc.)
-	httpReq, err := r.prepareHTTPRequest(ctx, url, c.cfg)
+	httpReq, err := r.prepareHTTPRequest(ctx, c.cfg)
 	logger.Debugf("Request body: %v", httpReq.Body)
 	logger.Debugf("Request headers: %v", httpReq.Header)
 
@@ -101,7 +99,10 @@ func (r *gsRequest) execute(ctx context.Context, c Client, output interface{}) e
 }
 
 //prepareHTTPRequest prepares a http request
-func (r *gsRequest) prepareHTTPRequest(ctx context.Context, url string, cfg *Config) (*http.Request, error) {
+func (r *gsRequest) prepareHTTPRequest(ctx context.Context, cfg *Config) (*http.Request, error) {
+	url := cfg.apiURL + r.uri
+	logger.Debugf("Preparing %v request sent to URL: %v", r.method, url)
+
 	//Convert the body of the request to json
 	jsonBody := new(bytes.Buffer)
 	if r.body != nil {

--- a/request.go
+++ b/request.go
@@ -193,7 +193,7 @@ func (r *gsRequest) retryHTTPRequest(ctx context.Context, c Client, httpReq *htt
 			if resp.StatusCode >= 500 || resp.StatusCode == 424 {
 				//retry (true) and accumulate error (in case that maximum number of retries is reached, and
 				//the latest error is still reported)
-				logger.Debugf("Retrying request: %v method sent to url %v with body %v", r.method, httpReq.RequestURI, r.body)
+				logger.Debugf("Retrying request: %v method sent to url %v with body %v", r.method, httpReq.URL.RequestURI(), r.body)
 				return true, errorMessage
 			}
 
@@ -207,7 +207,7 @@ func (r *gsRequest) retryHTTPRequest(ctx context.Context, c Client, httpReq *htt
 					return false, err
 				}
 				//Delay the retry until the rate limit is reset
-				logger.Debugf("Delay request for %d ms: %v method sent to url %v with body %v", delayMs, r.method, httpReq.RequestURI, r.body)
+				logger.Debugf("Delay request for %d ms: %v method sent to url %v with body %v", delayMs, r.method, httpReq.URL.RequestURI(), r.body)
 				time.Sleep(time.Duration(delayMs) * time.Millisecond)
 				return true, errorMessage
 			}

--- a/request.go
+++ b/request.go
@@ -204,5 +204,11 @@ func (r *gsRequest) retryHTTPRequest(ctx context.Context, c Client, httpReq *htt
 		//stop retrying (false) as no more errors
 		return false, nil
 	}, c.MaxNumberOfRetries(), c.DelayInterval())
+	//No need to return when the context is already expired.
+	select {
+	case <-ctx.Done():
+		return "", nil, ctx.Err()
+	default:
+	}
 	return requestUUID, responseBodyBytes, err
 }

--- a/request_test.go
+++ b/request_test.go
@@ -157,7 +157,7 @@ func TestRequestPatch_APIErrors(t *testing.T) {
 	}
 }
 
-func Test_getDelayTimeInMs(t *testing.T) {
+func Test_getDelayTimeInMsFromTimestampStr(t *testing.T) {
 	type testCase struct {
 		successful   bool
 		TimestampStr string
@@ -176,7 +176,7 @@ func Test_getDelayTimeInMs(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		delay, err := getDelayTimeInMs(test.TimestampStr)
+		delay, err := getDelayTimeInMsFromTimestampStr(test.TimestampStr)
 		if test.successful {
 			assert.Nil(t, err)
 			assert.GreaterOrEqual(t, delay, int64(0))

--- a/request_test.go
+++ b/request_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path"
+	"strconv"
 	"testing"
 	"time"
 
@@ -153,5 +154,34 @@ func TestRequestPatch_APIErrors(t *testing.T) {
 				Labels: nil,
 			})
 		assert.Contains(t, fmt.Sprintf("%v", err), fmt.Sprintf(test.expectedError, test.statusCode, dummyRequestUUID), test.name)
+	}
+}
+
+func Test_getDelayTimeInMs(t *testing.T) {
+	type testCase struct {
+		successful   bool
+		TimestampStr string
+	}
+	futureTimestamp := time.Now().Add(5*time.Second).UnixNano() / 1000000
+	futureTimestampStr := strconv.FormatInt(futureTimestamp, 10)
+	testCases := []testCase{
+		{
+			true,
+			futureTimestampStr,
+		},
+		{
+			false,
+			"",
+		},
+	}
+
+	for _, test := range testCases {
+		delay, err := getDelayTimeInMs(test.TimestampStr)
+		if test.successful {
+			assert.Nil(t, err)
+			assert.GreaterOrEqual(t, delay, int64(0))
+		} else {
+			assert.NotNil(t, err)
+		}
 	}
 }

--- a/request_test.go
+++ b/request_test.go
@@ -167,8 +167,8 @@ func Test_prepareHTTPRequest(t *testing.T) {
 	cfg := DefaultConfiguration("test", "test")
 	httpReq, err := r.prepareHTTPRequest(context.Background(), cfg)
 	assert.NotNil(t, httpReq)
-	assert.Equal(t, httpReq.Method, r.method)
-	assert.Equal(t, httpReq.URL.RequestURI(), r.uri)
+	assert.Equal(t, r.method, httpReq.Method)
+	assert.Equal(t, r.uri, httpReq.URL.RequestURI())
 	assert.Nil(t, err)
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -172,6 +172,35 @@ func Test_prepareHTTPRequest(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func Test_isErrorHTTPCodeRetryable(t *testing.T) {
+	type testCase struct {
+		code        int
+		isRetryable bool
+	}
+	testCases := []testCase{
+		{
+			500,
+			true,
+		},
+		{
+			424,
+			true,
+		},
+		{
+			429,
+			true,
+		},
+		{
+			404,
+			false,
+		},
+	}
+	for _, test := range testCases {
+		isRetryable := isErrorHTTPCodeRetryable(test.code)
+		assert.Equal(t, test.isRetryable, isRetryable)
+	}
+}
+
 func Test_getDelayTimeInMsFromTimestampStr(t *testing.T) {
 	type testCase struct {
 		successful   bool

--- a/request_test.go
+++ b/request_test.go
@@ -1,6 +1,7 @@
 package gsclient
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -155,6 +156,20 @@ func TestRequestPatch_APIErrors(t *testing.T) {
 			})
 		assert.Contains(t, fmt.Sprintf("%v", err), fmt.Sprintf(test.expectedError, test.statusCode, dummyRequestUUID), test.name)
 	}
+}
+
+func Test_prepareHTTPRequest(t *testing.T) {
+	r := &gsRequest{
+		uri:                 path.Join(apiDeletedBase, "networks"),
+		method:              http.MethodGet,
+		skipCheckingRequest: true,
+	}
+	cfg := DefaultConfiguration("test", "test")
+	httpReq, err := r.prepareHTTPRequest(context.Background(), cfg)
+	assert.NotNil(t, httpReq)
+	assert.Equal(t, httpReq.Method, r.method)
+	assert.Equal(t, httpReq.URL.RequestURI(), r.uri)
+	assert.Nil(t, err)
 }
 
 func Test_getDelayTimeInMsFromTimestampStr(t *testing.T) {

--- a/server.go
+++ b/server.go
@@ -294,7 +294,7 @@ func (c *Client) GetServer(ctx context.Context, id string) (Server, error) {
 	if !isValidUUID(id) {
 		return Server{}, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiServerBase, id),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -308,7 +308,7 @@ func (c *Client) GetServer(ctx context.Context, id string) (Server, error) {
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getServers
 func (c *Client) GetServerList(ctx context.Context) ([]Server, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 apiServerBase,
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -346,7 +346,7 @@ func (c *Client) CreateServer(ctx context.Context, body ServerCreateRequest) (Se
 	if body.Relations != nil && body.Relations.Storages == nil {
 		body.Relations.Storages = make([]ServerCreateRequestStorage, 0)
 	}
-	r := request{
+	r := gsRequest{
 		uri:    apiServerBase,
 		method: http.MethodPost,
 		body:   body,
@@ -370,7 +370,7 @@ func (c *Client) DeleteServer(ctx context.Context, id string) error {
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiServerBase, id),
 		method: http.MethodDelete,
 	}
@@ -384,7 +384,7 @@ func (c *Client) UpdateServer(ctx context.Context, id string, body ServerUpdateR
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiServerBase, id),
 		method: http.MethodPatch,
 		body:   body,
@@ -399,7 +399,7 @@ func (c *Client) GetServerEventList(ctx context.Context, id string) ([]Event, er
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiServerBase, id, "events"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -420,7 +420,7 @@ func (c *Client) GetServerMetricList(ctx context.Context, id string) ([]ServerMe
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiServerBase, id, "metrics"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -453,7 +453,7 @@ func (c *Client) setServerPowerState(ctx context.Context, id string, powerState 
 	if isOn == powerState {
 		return nil
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiServerBase, id, "power"),
 		method: http.MethodPatch,
 		body: ServerPowerUpdateRequest{
@@ -490,7 +490,7 @@ func (c *Client) ShutdownServer(ctx context.Context, id string) error {
 	if !server.Properties.Power {
 		return nil
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiServerBase, id, "shutdown"),
 		method: http.MethodPatch,
 		body:   map[string]string{},
@@ -518,7 +518,7 @@ func (c *Client) GetServersByLocation(ctx context.Context, id string) ([]Server,
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiLocationBase, id, "servers"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -536,7 +536,7 @@ func (c *Client) GetServersByLocation(ctx context.Context, id string) ([]Server,
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getDeletedServers
 func (c *Client) GetDeletedServers(ctx context.Context) ([]Server, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiDeletedBase, "servers"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,

--- a/serverip.go
+++ b/serverip.go
@@ -53,7 +53,7 @@ func (c *Client) GetServerIPList(ctx context.Context, id string) ([]ServerIPRela
 	if id == "" {
 		return nil, errors.New("'id' is required")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiServerBase, id, "ips"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -70,7 +70,7 @@ func (c *Client) GetServerIP(ctx context.Context, serverID, ipID string) (Server
 	if serverID == "" || ipID == "" {
 		return ServerIPRelationProperties{}, errors.New("'serverID' and 'ipID' are required")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiServerBase, serverID, "ips", ipID),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -87,7 +87,7 @@ func (c *Client) CreateServerIP(ctx context.Context, id string, body ServerIPRel
 	if id == "" || body.ObjectUUID == "" {
 		return errors.New("'server_id' and 'ip_id' are required")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiServerBase, id, "ips"),
 		method: http.MethodPost,
 		body:   body,
@@ -102,7 +102,7 @@ func (c *Client) DeleteServerIP(ctx context.Context, serverID, ipID string) erro
 	if serverID == "" || ipID == "" {
 		return errors.New("'serverID' and 'ipID' are required")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiServerBase, serverID, "ips", ipID),
 		method: http.MethodDelete,
 	}

--- a/serverisoimage.go
+++ b/serverisoimage.go
@@ -57,7 +57,7 @@ func (c *Client) GetServerIsoImageList(ctx context.Context, id string) ([]Server
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiServerBase, id, "isoimages"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -74,7 +74,7 @@ func (c *Client) GetServerIsoImage(ctx context.Context, serverID, isoImageID str
 	if !isValidUUID(serverID) || !isValidUUID(isoImageID) {
 		return ServerIsoImageRelationProperties{}, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiServerBase, serverID, "isoimages", isoImageID),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -91,7 +91,7 @@ func (c *Client) UpdateServerIsoImage(ctx context.Context, serverID, isoImageID 
 	if !isValidUUID(serverID) || !isValidUUID(isoImageID) {
 		return errors.New("'serverID' or 'isoImageID' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiServerBase, serverID, "isoimages", isoImageID),
 		method: http.MethodPatch,
 		body:   body,
@@ -106,7 +106,7 @@ func (c *Client) CreateServerIsoImage(ctx context.Context, id string, body Serve
 	if !isValidUUID(id) || !isValidUUID(body.ObjectUUID) {
 		return errors.New("'serverID' or 'isoImageID' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiServerBase, id, "isoimages"),
 		method: http.MethodPost,
 		body:   body,
@@ -121,7 +121,7 @@ func (c *Client) DeleteServerIsoImage(ctx context.Context, serverID, isoImageID 
 	if !isValidUUID(serverID) || !isValidUUID(isoImageID) {
 		return errors.New("'serverID' or 'isoImageID' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiServerBase, serverID, "isoimages", isoImageID),
 		method: http.MethodDelete,
 	}

--- a/servernetwork.go
+++ b/servernetwork.go
@@ -126,7 +126,7 @@ func (c *Client) GetServerNetworkList(ctx context.Context, id string) ([]ServerN
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiServerBase, id, "networks"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -143,7 +143,7 @@ func (c *Client) GetServerNetwork(ctx context.Context, serverID, networkID strin
 	if !isValidUUID(serverID) || !isValidUUID(networkID) {
 		return ServerNetworkRelationProperties{}, errors.New("'serverID' or 'networksID' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiServerBase, serverID, "networks", networkID),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -160,7 +160,7 @@ func (c *Client) UpdateServerNetwork(ctx context.Context, serverID, networkID st
 	if !isValidUUID(serverID) || !isValidUUID(networkID) {
 		return errors.New("'serverID' or 'networksID' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiServerBase, serverID, "networks", networkID),
 		method: http.MethodPatch,
 		body:   body,
@@ -175,7 +175,7 @@ func (c *Client) CreateServerNetwork(ctx context.Context, id string, body Server
 	if !isValidUUID(id) || !isValidUUID(body.ObjectUUID) {
 		return errors.New("'serverID' or 'network_id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiServerBase, id, "networks"),
 		method: http.MethodPost,
 		body:   body,
@@ -190,7 +190,7 @@ func (c *Client) DeleteServerNetwork(ctx context.Context, serverID, networkID st
 	if !isValidUUID(serverID) || !isValidUUID(networkID) {
 		return errors.New("'serverID' or 'networkID' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiServerBase, serverID, "networks", networkID),
 		method: http.MethodDelete,
 	}

--- a/serverstorage.go
+++ b/serverstorage.go
@@ -96,7 +96,7 @@ func (c *Client) GetServerStorageList(ctx context.Context, id string) ([]ServerS
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiServerBase, id, "storages"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -113,7 +113,7 @@ func (c *Client) GetServerStorage(ctx context.Context, serverID, storageID strin
 	if !isValidUUID(serverID) || !isValidUUID(storageID) {
 		return ServerStorageRelationProperties{}, errors.New("'serverID' or 'storageID' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiServerBase, serverID, "storages", storageID),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -130,7 +130,7 @@ func (c *Client) UpdateServerStorage(ctx context.Context, serverID, storageID st
 	if !isValidUUID(serverID) || !isValidUUID(storageID) {
 		return errors.New("'serverID' or 'storageID' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiServerBase, serverID, "storages", storageID),
 		method: http.MethodPatch,
 		body:   body,
@@ -145,7 +145,7 @@ func (c *Client) CreateServerStorage(ctx context.Context, id string, body Server
 	if !isValidUUID(id) || !isValidUUID(body.ObjectUUID) {
 		return errors.New("'server_id' or 'storage_id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiServerBase, id, "storages"),
 		method: http.MethodPost,
 		body:   body,
@@ -160,7 +160,7 @@ func (c *Client) DeleteServerStorage(ctx context.Context, serverID, storageID st
 	if !isValidUUID(serverID) || !isValidUUID(storageID) {
 		return errors.New("'serverID' or 'storageID' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiServerBase, serverID, "storages", storageID),
 		method: http.MethodDelete,
 	}

--- a/snapshot.go
+++ b/snapshot.go
@@ -152,7 +152,7 @@ func (c *Client) GetStorageSnapshotList(ctx context.Context, id string) ([]Stora
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiStorageBase, id, "snapshots"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -173,7 +173,7 @@ func (c *Client) GetStorageSnapshot(ctx context.Context, storageID, snapshotID s
 	if !isValidUUID(storageID) || !isValidUUID(snapshotID) {
 		return StorageSnapshot{}, errors.New("'storageID' or 'snapshotID' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiStorageBase, storageID, "snapshots", snapshotID),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -190,7 +190,7 @@ func (c *Client) CreateStorageSnapshot(ctx context.Context, id string, body Stor
 	if !isValidUUID(id) {
 		return StorageSnapshotCreateResponse{}, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiStorageBase, id, "snapshots"),
 		method: http.MethodPost,
 		body:   body,
@@ -207,7 +207,7 @@ func (c *Client) UpdateStorageSnapshot(ctx context.Context, storageID, snapshotI
 	if !isValidUUID(storageID) || !isValidUUID(snapshotID) {
 		return errors.New("'storageID' or 'snapshotID' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiStorageBase, storageID, "snapshots", snapshotID),
 		method: http.MethodPatch,
 		body:   body,
@@ -222,7 +222,7 @@ func (c *Client) DeleteStorageSnapshot(ctx context.Context, storageID, snapshotI
 	if !isValidUUID(storageID) || !isValidUUID(snapshotID) {
 		return errors.New("'storageID' or 'snapshotID' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiStorageBase, storageID, "snapshots", snapshotID),
 		method: http.MethodDelete,
 	}
@@ -236,7 +236,7 @@ func (c *Client) RollbackStorage(ctx context.Context, storageID, snapshotID stri
 	if !isValidUUID(storageID) || !isValidUUID(snapshotID) {
 		return errors.New("'storageID' or 'snapshotID' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiStorageBase, storageID, "snapshots", snapshotID, "rollback"),
 		method: http.MethodPatch,
 		body:   body,
@@ -251,7 +251,7 @@ func (c *Client) ExportStorageSnapshotToS3(ctx context.Context, storageID, snaps
 	if !isValidUUID(storageID) || !isValidUUID(snapshotID) {
 		return errors.New("'storageID' and 'snapshotID' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiStorageBase, storageID, "snapshots", snapshotID, "export_to_s3"),
 		method: http.MethodPatch,
 		body:   body,
@@ -266,7 +266,7 @@ func (c *Client) GetSnapshotsByLocation(ctx context.Context, id string) ([]Stora
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiLocationBase, id, "snapshots"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -284,7 +284,7 @@ func (c *Client) GetSnapshotsByLocation(ctx context.Context, id string) ([]Stora
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getDeletedSnapshots
 func (c *Client) GetDeletedSnapshots(ctx context.Context) ([]StorageSnapshot, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiDeletedBase, "snapshots"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,

--- a/snapshotscheduler.go
+++ b/snapshotscheduler.go
@@ -132,7 +132,7 @@ func (c *Client) GetStorageSnapshotScheduleList(ctx context.Context, id string) 
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiStorageBase, id, "snapshot_schedules"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -153,7 +153,7 @@ func (c *Client) GetStorageSnapshotSchedule(ctx context.Context, storageID, sche
 	if !isValidUUID(storageID) || !isValidUUID(scheduleID) {
 		return StorageSnapshotSchedule{}, errors.New("'storageID' or 'scheduleID' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiStorageBase, storageID, "snapshot_schedules", scheduleID),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -171,7 +171,7 @@ func (c *Client) CreateStorageSnapshotSchedule(ctx context.Context, id string, b
 	if !isValidUUID(id) {
 		return StorageSnapshotScheduleCreateResponse{}, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiStorageBase, id, "snapshot_schedules"),
 		method: http.MethodPost,
 		body:   body,
@@ -189,7 +189,7 @@ func (c *Client) UpdateStorageSnapshotSchedule(ctx context.Context, storageID, s
 	if !isValidUUID(storageID) || !isValidUUID(scheduleID) {
 		return errors.New("'storageID' or 'scheduleID' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiStorageBase, storageID, "snapshot_schedules", scheduleID),
 		method: http.MethodPatch,
 		body:   body,
@@ -204,7 +204,7 @@ func (c *Client) DeleteStorageSnapshotSchedule(ctx context.Context, storageID, s
 	if !isValidUUID(storageID) || !isValidUUID(scheduleID) {
 		return errors.New("'storageID' or 'scheduleID' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiStorageBase, storageID, "snapshot_schedules", scheduleID),
 		method: http.MethodDelete,
 	}

--- a/sshkey.go
+++ b/sshkey.go
@@ -78,7 +78,7 @@ func (c *Client) GetSshkey(ctx context.Context, id string) (Sshkey, error) {
 	if !isValidUUID(id) {
 		return Sshkey{}, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiSshkeyBase, id),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -92,7 +92,7 @@ func (c *Client) GetSshkey(ctx context.Context, id string) (Sshkey, error) {
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getSshKeys
 func (c *Client) GetSshkeyList(ctx context.Context) ([]Sshkey, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 apiSshkeyBase,
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -111,7 +111,7 @@ func (c *Client) GetSshkeyList(ctx context.Context) ([]Sshkey, error) {
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/createSshKey
 func (c *Client) CreateSshkey(ctx context.Context, body SshkeyCreateRequest) (CreateResponse, error) {
-	r := request{
+	r := gsRequest{
 		uri:    apiSshkeyBase,
 		method: "POST",
 		body:   body,
@@ -128,7 +128,7 @@ func (c *Client) DeleteSshkey(ctx context.Context, id string) error {
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiSshkeyBase, id),
 		method: http.MethodDelete,
 	}
@@ -142,7 +142,7 @@ func (c *Client) UpdateSshkey(ctx context.Context, id string, body SshkeyUpdateR
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiSshkeyBase, id),
 		method: http.MethodPatch,
 		body:   body,
@@ -157,7 +157,7 @@ func (c *Client) GetSshkeyEventList(ctx context.Context, id string) ([]Event, er
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiSshkeyBase, id, "events"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,

--- a/storage.go
+++ b/storage.go
@@ -248,7 +248,7 @@ func (c *Client) GetStorage(ctx context.Context, id string) (Storage, error) {
 	if !isValidUUID(id) {
 		return Storage{}, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiStorageBase, id),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -262,7 +262,7 @@ func (c *Client) GetStorage(ctx context.Context, id string) (Storage, error) {
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getStorages
 func (c *Client) GetStorageList(ctx context.Context) ([]Storage, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 apiStorageBase,
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -288,7 +288,7 @@ func (c *Client) GetStorageList(ctx context.Context) ([]Storage, error) {
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/createStorage
 func (c *Client) CreateStorage(ctx context.Context, body StorageCreateRequest) (CreateResponse, error) {
-	r := request{
+	r := gsRequest{
 		uri:    apiStorageBase,
 		method: http.MethodPost,
 		body:   body,
@@ -305,7 +305,7 @@ func (c *Client) DeleteStorage(ctx context.Context, id string) error {
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiStorageBase, id),
 		method: http.MethodDelete,
 	}
@@ -319,7 +319,7 @@ func (c *Client) UpdateStorage(ctx context.Context, id string, body StorageUpdat
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiStorageBase, id),
 		method: http.MethodPatch,
 		body:   body,
@@ -334,7 +334,7 @@ func (c *Client) GetStorageEventList(ctx context.Context, id string) ([]Event, e
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiStorageBase, id, "events"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -355,7 +355,7 @@ func (c *Client) GetStoragesByLocation(ctx context.Context, id string) ([]Storag
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiLocationBase, id, "storages"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -373,7 +373,7 @@ func (c *Client) GetStoragesByLocation(ctx context.Context, id string) ([]Storag
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getDeletedStorages
 func (c *Client) GetDeletedStorages(ctx context.Context) ([]Storage, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiDeletedBase, "storages"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -394,7 +394,7 @@ func (c *Client) CloneStorage(ctx context.Context, id string) (CreateResponse, e
 	if !isValidUUID(id) {
 		return response, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiStorageBase, id, "clone"),
 		method: http.MethodPost,
 	}

--- a/template.go
+++ b/template.go
@@ -116,7 +116,7 @@ func (c *Client) GetTemplate(ctx context.Context, id string) (Template, error) {
 	if !isValidUUID(id) {
 		return Template{}, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiTemplateBase, id),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -130,7 +130,7 @@ func (c *Client) GetTemplate(ctx context.Context, id string) (Template, error) {
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getTemplates
 func (c *Client) GetTemplateList(ctx context.Context) ([]Template, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 apiTemplateBase,
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -167,7 +167,7 @@ func (c *Client) GetTemplateByName(ctx context.Context, name string) (Template, 
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/createTemplate
 func (c *Client) CreateTemplate(ctx context.Context, body TemplateCreateRequest) (CreateResponse, error) {
-	r := request{
+	r := gsRequest{
 		uri:    apiTemplateBase,
 		method: http.MethodPost,
 		body:   body,
@@ -184,7 +184,7 @@ func (c *Client) UpdateTemplate(ctx context.Context, id string, body TemplateUpd
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiTemplateBase, id),
 		method: http.MethodPatch,
 		body:   body,
@@ -199,7 +199,7 @@ func (c *Client) DeleteTemplate(ctx context.Context, id string) error {
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:    path.Join(apiTemplateBase, id),
 		method: http.MethodDelete,
 	}
@@ -213,7 +213,7 @@ func (c *Client) GetTemplateEventList(ctx context.Context, id string) ([]Event, 
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiTemplateBase, id, "events"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -234,7 +234,7 @@ func (c *Client) GetTemplatesByLocation(ctx context.Context, id string) ([]Templ
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiLocationBase, id, "templates"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
@@ -252,7 +252,7 @@ func (c *Client) GetTemplatesByLocation(ctx context.Context, id string) ([]Templ
 //
 //See: https://gridscale.io/en//api-documentation/index.html#operation/getDeletedTemplates
 func (c *Client) GetDeletedTemplates(ctx context.Context) ([]Template, error) {
-	r := request{
+	r := gsRequest{
 		uri:                 path.Join(apiDeletedBase, "templates"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,


### PR DESCRIPTION
Changes:
- function `execute()` is refactored to make it easier to test, and easier to handle error status codes.
- handle 429 (rate limit reached) by waiting until the rate limit is reset.
- some small refactored code lines (e.g renaming `request` struct, adding some comments, making logger global, etc.)