### PR TITLE
Fix bug 164 - retry request when 409 is returned

### DIFF
--- a/request.go
+++ b/request.go
@@ -244,7 +244,7 @@ func isErrorHTTPCodeRetryable(statusCode int) bool {
 	//if internal server error (>=500)
 	//OR object is in status that does not allow the request (424)
 	//OR we reach the rate limit (429), retry
-	if statusCode >= 500 || statusCode == 424 || statusCode == 429 {
+	if statusCode >= 500 || statusCode == 424 || statusCode == 429 || statusCode == 409 {
 		return true
 	}
 	//stop retrying (false) and return custom error

--- a/request_test.go
+++ b/request_test.go
@@ -164,6 +164,20 @@ func TestRequestPatch_APIErrors(t *testing.T) {
 	}
 }
 
+func TestRequestDelete_APIErrors(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	for _, test := range apiErrorTests {
+		uri := path.Join(apiServerBase, test.dummyUUID)
+		mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+			w.WriteHeader(test.statusCode)
+		})
+		err := client.DeleteServer(emptyCtx, test.dummyUUID)
+		assert.Contains(t, fmt.Sprintf("%v", err), fmt.Sprintf(test.expectedError, test.statusCode, dummyRequestUUID), test.name)
+	}
+}
+
 func Test_prepareHTTPRequest(t *testing.T) {
 	r := &gsRequest{
 		uri:                 path.Join(apiDeletedBase, "networks"),

--- a/request_test.go
+++ b/request_test.go
@@ -82,6 +82,12 @@ var apiErrorTests = []apiTestCase{
 		dummyUUID:     "690de890-13c0-4e76-8a01-e10ba8786e54",
 		expectedError: "Maximum number of trials has been exhausted with error: Status code: %d. Error: no error message received from server. Request UUID: %s. ",
 	},
+	{
+		name:          "retry the request in case of API error with status code 409",
+		statusCode:    409,
+		dummyUUID:     "690de890-13c0-4e76-8a01-e10ba8786e55",
+		expectedError: "Maximum number of trials has been exhausted with error: Status code: %d. Error: no error message received from server. Request UUID: %s.",
+	},
 }
 
 func TestRequestGet_NetworkErrors(t *testing.T) {
@@ -188,6 +194,10 @@ func Test_isErrorHTTPCodeRetryable(t *testing.T) {
 		},
 		{
 			429,
+			true,
+		},
+		{
+			409,
 			true,
 		},
 		{


### PR DESCRIPTION
- Add 409 to retriable http code -> when 409 is return, the request will be sent again until timeout is reached.
- Add test case for 409 case.