### PR TITLE
cast type of err in retryWithLimitedNumOfRetries

### DIFF
--- a/common.go
+++ b/common.go
@@ -54,6 +54,9 @@ func retryWithLimitedNumOfRetries(targetFunc retryableFunc, numOfRetries int, de
 	if err != nil {
 		reqErr, ok := err.(RequestError)
 		if ok {
+			if reqErr.Description == "" {
+				reqErr.Description = "no error message received from server"
+			}
 			reqErr.Description = fmt.Sprintf("Maximum number of trials has been exhausted with error: %s", reqErr.Description)
 			return reqErr
 		}

--- a/common.go
+++ b/common.go
@@ -52,6 +52,11 @@ func retryWithLimitedNumOfRetries(targetFunc retryableFunc, numOfRetries int, de
 
 	}
 	if err != nil {
+		reqErr, ok := err.(RequestError)
+		if ok {
+			reqErr.Description = fmt.Sprintf("Maximum number of trials has been exhausted with error: %s", reqErr.Description)
+			return reqErr
+		}
 		return fmt.Errorf("Maximum number of trials has been exhausted with error: %v", err)
 	}
 	return errors.New("Maximum number of trials has been exhausted")

--- a/common.go
+++ b/common.go
@@ -37,8 +37,8 @@ func retryWithContext(ctx context.Context, targetFunc retryableFunc, delay time.
 	}
 }
 
-//retryWithLimitedNumOfRetries reruns a function within a number of retries
-func retryWithLimitedNumOfRetries(targetFunc retryableFunc, numOfRetries int, delay time.Duration) error {
+//retryNTimes reruns a function within a number of retries
+func retryNTimes(targetFunc retryableFunc, numOfRetries int, delay time.Duration) error {
 	retryNo := 0
 	var err error
 	var continueRetrying bool

--- a/common_test.go
+++ b/common_test.go
@@ -79,7 +79,7 @@ func Test_retryWithContext(t *testing.T) {
 	}
 }
 
-func Test_retryWithLimitedNumOfRetries(t *testing.T) {
+func Test_retryNTimes(t *testing.T) {
 	type testCase struct {
 		isContinue   bool
 		err          error
@@ -107,7 +107,7 @@ func Test_retryWithLimitedNumOfRetries(t *testing.T) {
 		},
 	}
 	for _, test := range testCases {
-		err := retryWithLimitedNumOfRetries(func() (bool, error) {
+		err := retryNTimes(func() (bool, error) {
 			return test.isContinue, test.err
 		}, test.numOfRetries, test.delay)
 		if test.err != nil || test.isContinue {

--- a/request.go
+++ b/request.go
@@ -154,7 +154,7 @@ func (r *gsRequest) retryHTTPRequest(
 	//Init empty response body
 	var responseBodyBytes []byte
 	//
-	err := retryWithLimitedNumOfRetries(func() (bool, error) {
+	err := retryNTimes(func() (bool, error) {
 		//execute the request
 		resp, err := httpClient.Do(httpReq)
 		if err != nil {

--- a/request_test.go
+++ b/request_test.go
@@ -74,19 +74,19 @@ var apiErrorTests = []apiTestCase{
 		name:          "retry the request in case of API error with status code 500",
 		statusCode:    500,
 		dummyUUID:     "690de890-13c0-4e76-8a01-e10ba8786e53",
-		expectedError: "Maximum number of trials has been exhausted with error: Status code: %d. Error: no error message received from server. Request UUID: %s.",
+		expectedError: "Status code: %d. Error: Maximum number of trials has been exhausted with error: no error message received from server. Request UUID: %s.",
 	},
 	{
 		name:          "retry the request in case of API error with status code 424",
 		statusCode:    424,
 		dummyUUID:     "690de890-13c0-4e76-8a01-e10ba8786e54",
-		expectedError: "Maximum number of trials has been exhausted with error: Status code: %d. Error: no error message received from server. Request UUID: %s. ",
+		expectedError: "Status code: %d. Error: Maximum number of trials has been exhausted with error: no error message received from server. Request UUID: %s.",
 	},
 	{
 		name:          "retry the request in case of API error with status code 409",
 		statusCode:    409,
 		dummyUUID:     "690de890-13c0-4e76-8a01-e10ba8786e55",
-		expectedError: "Maximum number of trials has been exhausted with error: Status code: %d. Error: no error message received from server. Request UUID: %s.",
+		expectedError: "Status code: %d. Error: Maximum number of trials has been exhausted with error: no error message received from server. Request UUID: %s.",
 	},
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -330,7 +330,7 @@ func TestClient_ShutdownServer(t *testing.T) {
 				})
 				err := client.ShutdownServer(emptyCtx, dummyUUID)
 				assert.Contains(t, fmt.Sprintf("%v", err),
-					fmt.Sprintf("Maximum number of trials has been exhausted with error: Status code: 500. Error: no error message received from server. Request UUID: %s.",
+					fmt.Sprintf("Status code: 500. Error: Maximum number of trials has been exhausted with error: no error message received from server. Request UUID: %s.",
 						dummyRequestUUID), "ShutdownServer returned an error with status code 500")
 				server.Close()
 			}


### PR DESCRIPTION
If the error is type of RequestError, convert the error to RequestError and return it. This helps to solve the issue in gs tf provider [tf PR #107](https://github.com/gridscale/terraform-provider-gridscale/pull/107)