### PR TITLE
PaaSServiceTemplateUUID can be updated

### DIFF
--- a/paas.go
+++ b/paas.go
@@ -253,6 +253,9 @@ type PaaSServiceUpdateRequest struct {
 
 	//A list of service resource limits. Leave it if you do not want to update the resource limits
 	ResourceLimits []ResourceLimit `json:"resource_limits,omitempty"`
+
+	//The template that you want to use in the service, you can find an available list at the /service_templates endpoint.
+	PaaSServiceTemplateUUID string `json:"paas_service_template_uuid,omitempty"`
 }
 
 //PaaSServiceMetrics JSON of a list of PaaS metrics


### PR DESCRIPTION
The new API allows PaaS to be updated is `paas_service_template_uuid`: [PaaS Patch](https://gridscale.io/en/api-documentation/index.html#operation/updatePaasService)