### PR TITLE
Mask the credentials in HTTP header when printing the debug log

### DIFF
--- a/request.go
+++ b/request.go
@@ -281,9 +281,9 @@ func maskHeaderCred(header http.Header) http.Header {
 		if k == authUserIDHeaderKey || k == authTokenHeaderKey {
 			if len(v[0]) > 5 {
 				newHeaders[k] = []string{v[0][:5] + maskedValue}
-			} else {
-				newHeaders[k] = []string{maskedValue}
+				continue
 			}
+			newHeaders[k] = []string{maskedValue}
 			continue
 		}
 		newHeaders[k] = v

--- a/request.go
+++ b/request.go
@@ -279,7 +279,11 @@ func maskHeaderCred(header http.Header) http.Header {
 	newHeaders := make(http.Header)
 	for k, v := range header {
 		if k == authUserIDHeaderKey || k == authTokenHeaderKey {
-			newHeaders[k] = []string{v[0][:5] + maskedValue}
+			if len(v[0]) > 5 {
+				newHeaders[k] = []string{v[0][:5] + maskedValue}
+			} else {
+				newHeaders[k] = []string{maskedValue}
+			}
 			continue
 		}
 		newHeaders[k] = v


### PR DESCRIPTION
- Mask the credentials in HTTP header when printing the debug log. Only reveal the first 5 characters.
Solve issue #182 