### PR TITLE
Allow tracing of request durations & performance improvement

### DIFF
--- a/common.go
+++ b/common.go
@@ -43,13 +43,12 @@ func retryNTimes(targetFunc retryableFunc, numOfRetries int, delay time.Duration
 	var err error
 	var continueRetrying bool
 	for retryNo <= numOfRetries {
-		retryNo++
-		time.Sleep(delay * time.Duration(retryNo)) //delay between retries
 		continueRetrying, err = targetFunc()
 		if !continueRetrying {
 			return err
 		}
-
+		retryNo++
+		time.Sleep(delay * time.Duration(retryNo)) //delay between retries
 	}
 	if err != nil {
 		reqErr, ok := err.(RequestError)

--- a/common.go
+++ b/common.go
@@ -28,11 +28,11 @@ func retryWithContext(ctx context.Context, targetFunc retryableFunc, delay time.
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			time.Sleep(delay) //delay between retries
 			continueRetrying, err := targetFunc()
 			if !continueRetrying {
 				return err
 			}
+			time.Sleep(delay) //delay between retries
 		}
 	}
 }

--- a/config.go
+++ b/config.go
@@ -86,3 +86,9 @@ func DefaultConfiguration(uuid string, token string) *Config {
 	}
 	return cfg
 }
+
+// SetLogLevel manually sets log level.
+// Read more: https://github.com/sirupsen/logrus#level-logging
+func SetLogLevel(level logrus.Level) {
+	logger.Level = level
+}


### PR DESCRIPTION
Changes:
- Allow to set log level manually via `SetLogLevel` fucntion.
- Tracing of request (method) durations and status (successful or unsuccessful).
Improvement:
- Only delay after running a retriable function => runtime is reduced up to 60%. [More](https://github.com/gridscale/gsclient-go/issues/186#issuecomment-795466954)