### PR TITLE
Add Certificate CRUD operations & fix loadbalancer SSL certificate issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,5 +312,10 @@ Not all endpoints have been implemented in this client, but new ones will be add
   * Deleted Storages Get (GetDeletedStorages)
   * Deleted Templates Get (GetDeletedTemplates)
   * Deleted PaaS Services Get (GetDeletedPaaSServices)
+* SSL certificate
+  * SSL certificates Get (GetSSLCertificateList)
+  * SSL certificate Get (GetSSLCertificate)
+  * SSL certificate Create (CreateSSLCertificate)
+  * SSL certificate Delete (DeleteSSLCertificate)
 
 Note: The functions in this list can be called with a Client type.

--- a/client.go
+++ b/client.go
@@ -27,6 +27,7 @@ const (
 	apiEventBase                  = "/objects/events"
 	apiLabelBase                  = "/objects/labels"
 	apiDeletedBase                = "/objects/deleted"
+	apiSSLCertificateBase         = "/objects/certificates"
 )
 
 // Client struct of a gridscale golang client.

--- a/examples/sslcert.go
+++ b/examples/sslcert.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"os"
+
+	"github.com/gridscale/gsclient-go/v3"
+	log "github.com/sirupsen/logrus"
+)
+
+var emptyCtx = context.Background()
+
+// examplePrivateKey is an example of a SSL certificate private key, don't use it in production
+const examplePrivateKey = "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC1AWnQPQpH3tNs\n+FpvmGRMS5I1wXuXSe3tpX65sdk+w9ZcatohQ0OAFYRE4cTBCWkIzjjymjdr1h2l\nsazjfBC8V67c2lk27iMo1q3rSYFFh4Z01AxpWadKEsE1IdbGc7O16TNSiWNM9gOA\njIHJqeXomj3BRRhBlqSLAPHPI2Y6nxtWQcWE89u3YLUEI9d3HEphhSzB83EdSp2c\ndEkjh4+LMFi98XwQNbdgOM3f+V2NnEK4kqGZG3U+JZEkHI/CZ4NSgLC1AkGltjdb\nzg5x5KKNM3caRugXluYGuQI/Ec0aR07IgxP2N3jlmQfT/85WbMH8OuBDlBY4tHyI\ntU6nqjJfAgMBAAECggEAZirmDyRlKSwdKuUEJvldo7MEVFNh74NLSVigrzAz77ma\nxY+KkDvnXeTHRBordMpa/x1oB4gEwFmbYmtnqv/ccnMLwJ1+vgKs1eBXSveygAx/\nWHJYjx6LzsPHSrZPBLVKOuPmlC/4XPiAAY9NswazPxfQw8a8akkdl1hxJPpWOb+h\nssonF5Gzt4DxHKd25Lplt1iDgRl0ilIvnLZk2Mkkl1OuVwLtngGKjWBm4d/Obtoy\nEUiNnIp7l86miPz5pXmpY/NJSy6/oOVceoDj+pR4eBNlI1QJNaCrGAO6JA8Hdh8I\nibNWWQBK7lQBFJr9JC8/NKbxEXZide+Fesxi7/KMAQKBgQDlIK/757GbaCLg5JUx\nTLsAKvi1RD4iOtdkwCFowgonVtDwlw7G5WjQAVC6n8SLGCAfspNWKtfS8n5iq9rb\nKV4dno/xPhI7n2kFRbM2IGrUAdLgS/KgI7E4Y4AuPxPJLcgeTk+g/LCjfoZFP3IJ\nladyPKh1eDrj9YLzEqc4hhRr6wKBgQDKO+jcbQgnAAornSwwRJ0Cj5XNrjpAdsb5\nM1A1UFdV0hnUz7wkjT4B14XUyQSnZUJUxV6/qI+lmfoEOuPKgTUkZATO+hfPcFfX\n9K8B+5qr6TD+9AYFcyoaM0kXC+Mjxwa6Yd6h1mFhezufT0Qfjfji/N84zGdz8ucp\nDrvxZTN6XQKBgFMURhtNyH10BemLmHkWvFt0OVfolartsPoMHFESwoG/HeWOsEH4\nHsgFIhN5KNfSeJtlsby1rioD2UXH0IRU/JY6zzCG9C+APqE1w6Rlnraerqq7fw8H\nwhOTKIAcSP1SR1SNypux5A50KxViyuOkyuFGE0L8xEWx2LhwVAfPvgnfAoGAffMx\n45ZELYXoz6DjlGwnHSEvuxl3Tg6rfShoG8wdmGVxkQiPtHQC2kLQJuXK8DYwSXti\ntxrT2985xsimdchiwHdKR12a1qaxDt5k4GdCvS5ORXrVBS/kWMz4CFJu9ClQF2Q8\ns65Al+WYDG/hjYVuLHAw1b73706oiPmUM5NDrEECgYBiak2SnpPXAfJZCtyc/aIA\nCHpH6iGrO04ERItcX8skDiyw+qoUvWmPZIY8KGyF2tF9uVhZoBE4cxn5q1x52RDg\nUV7Ax9IGPvQU9gGuzSIMjEzgitmsGRi1YRAQJ0UaBciTRCS0Jf12zFg/P7a0RyvU\naZ9BxDQPOR71IkWZMIF6EQ==\n-----END PRIVATE KEY-----"
+
+// exampleLeafCert is an example of a SSL certificate's leaf certificate, don't use it in production
+const exampleLeafCert = "-----BEGIN CERTIFICATE-----\nMIIDZDCCAkwCCQDAfYZ8/ZCtYDANBgkqhkiG9w0BAQsFADB0MQswCQYDVQQGEwJH\nRTEMMAoGA1UECAwDQkVSMQwwCgYDVQQHDANCRVIxDDAKBgNVBAoMA29nczEMMAoG\nA1UECwwDb2dzMRQwEgYDVQQDDAt3d3cub2dzLmNvbTEXMBUGCSqGSIb3DQEJARYI\naWlAbC5jb20wHhcNMjEwMTIwMTE1NzAyWhcNMjIwMTIwMTE1NzAyWjB0MQswCQYD\nVQQGEwJHRTEMMAoGA1UECAwDQkVSMQwwCgYDVQQHDANCRVIxDDAKBgNVBAoMA29n\nczEMMAoGA1UECwwDb2dzMRQwEgYDVQQDDAt3d3cub2dzLmNvbTEXMBUGCSqGSIb3\nDQEJARYIaWlAbC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC1\nAWnQPQpH3tNs+FpvmGRMS5I1wXuXSe3tpX65sdk+w9ZcatohQ0OAFYRE4cTBCWkI\nzjjymjdr1h2lsazjfBC8V67c2lk27iMo1q3rSYFFh4Z01AxpWadKEsE1IdbGc7O1\n6TNSiWNM9gOAjIHJqeXomj3BRRhBlqSLAPHPI2Y6nxtWQcWE89u3YLUEI9d3HEph\nhSzB83EdSp2cdEkjh4+LMFi98XwQNbdgOM3f+V2NnEK4kqGZG3U+JZEkHI/CZ4NS\ngLC1AkGltjdbzg5x5KKNM3caRugXluYGuQI/Ec0aR07IgxP2N3jlmQfT/85WbMH8\nOuBDlBY4tHyItU6nqjJfAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAH3VDEuIKeIt\nDMzvs4gxowrKyUKP2OzIc447QA34RgiDiroFivV5G133yXmoTJ9YJnUnSbDFtZIY\n/zcY0JhLmBnFDfg4Uim+x7TA2+S3JOdZKV6rg3/CMJ2WYSqczj17c8MI5XQDOZGd\nHvCc5+XrOfWKWbY2toxCw1xpB325r9ufw3hS/NGaVRsvBsJ8A9b5TGLkoUTGR5pl\nPXfgoi4n3fvotDo6Ew1hp0Xlcxriqf/cmMX110cpsXbA4hm9OCv+vKWliOF7EWUO\nZfaaZlI4LuEw1ukFPVgGVeFBUsDAwbxLuVx3u5DVGM/3oj86bgmiBSYySLW5zoYc\nz72bskKMaeg=\n-----END CERTIFICATE-----"
+
+func main() {
+	uuid := os.Getenv("GRIDSCALE_UUID")
+	token := os.Getenv("GRIDSCALE_TOKEN")
+	config := gsclient.DefaultConfiguration(uuid, token)
+	client := gsclient.NewClient(config)
+	log.Info("gridscale client configured")
+
+	log.Info("Create SSL certificate: Press 'Enter' to continue...")
+	bufio.NewReader(os.Stdin).ReadBytes('\n')
+	cSSLCert, err := client.CreateSSLCertificate(
+		emptyCtx,
+		gsclient.SSLCertificateCreateRequest{
+			Name:            "go-client-ssl-cert",
+			PrivateKey:      examplePrivateKey,
+			LeafCertificate: exampleLeafCert,
+		})
+	if err != nil {
+		log.Error("Create SSL certificate has failed with error", err)
+		return
+	}
+	log.WithFields(log.Fields{
+		"sslcert_uuid": cSSLCert.ObjectUUID,
+	}).Info("SSL certificate is successfully created")
+	defer func() {
+		err := client.DeleteSSLCertificate(emptyCtx, cSSLCert.ObjectUUID)
+		if err != nil {
+			log.Error("Delete SSL certificate has failed with error", err)
+			return
+		}
+		log.Info("SSL certificate has been successfully deleted")
+	}()
+
+	log.Info("Get a SSL certificate: Press 'Enter' to continue...")
+	bufio.NewReader(os.Stdin).ReadBytes('\n')
+	sslCert, err := client.GetSSLCertificate(emptyCtx, cSSLCert.ObjectUUID)
+	if err != nil {
+		log.Error("Get SSL certificate has failed with error", err)
+		return
+	}
+	log.WithFields(log.Fields{
+		"sslcert": sslCert,
+	}).Info("SSL certificate is successfully retrieved")
+
+	log.Info("Get a list of SSL certificates: Press 'Enter' to continue...")
+	bufio.NewReader(os.Stdin).ReadBytes('\n')
+	sslCertList, err := client.GetSSLCertificateList(emptyCtx)
+	if err != nil {
+		log.Error("Get SSL certificate list has failed with error", err)
+		return
+	}
+	log.WithFields(log.Fields{
+		"sslcerts": sslCertList,
+	}).Info("SSL certificate list is successfully retrieved")
+
+	log.Info("Delete SSL certificate: Press 'Enter' to continue...")
+	bufio.NewReader(os.Stdin).ReadBytes('\n')
+}

--- a/examples/sslcert.go
+++ b/examples/sslcert.go
@@ -32,6 +32,7 @@ func main() {
 			Name:            "go-client-ssl-cert",
 			PrivateKey:      examplePrivateKey,
 			LeafCertificate: exampleLeafCert,
+			Labels:          []string{"test"},
 		})
 	if err != nil {
 		log.Error("Create SSL certificate has failed with error", err)

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -101,8 +101,8 @@ type BackendServer struct {
 // ForwardingRule represents a forwarding rule.
 // It tells which port are forwarded to which port.
 type ForwardingRule struct {
-	// SSL from LetsEncrypt.
-	LetsencryptSSL interface{} `json:"letsencrypt_ssl"`
+	// A valid domain name that points to the loadbalancer's IP address.
+	LetsencryptSSL *string `json:"letsencrypt_ssl"`
 
 	// Listen port.
 	ListenPort int `json:"listen_port"`

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -104,6 +104,9 @@ type ForwardingRule struct {
 	// A valid domain name that points to the loadbalancer's IP address.
 	LetsencryptSSL *string `json:"letsencrypt_ssl"`
 
+	// The UUID of a custom certificate.
+	CertificateUUID string `json:"certificate_uuid,omitempty"`
+
 	// Listen port.
 	ListenPort int `json:"listen_port"`
 

--- a/loadbalancer_test.go
+++ b/loadbalancer_test.go
@@ -195,7 +195,7 @@ func getMockLoadbalancer(status string) LoadBalancer {
 			RedirectHTTPToHTTPS: false,
 			ForwardingRules: []ForwardingRule{
 				{
-					LetsencryptSSL: "",
+					LetsencryptSSL: nil,
 					ListenPort:     8080,
 					Mode:           "http",
 					TargetPort:     8000,

--- a/ssl_certificate.go
+++ b/ssl_certificate.go
@@ -1,0 +1,142 @@
+package gsclient
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"path"
+)
+
+// SSLCertificateList holds a list of SSL certificates.
+type SSLCertificateList struct {
+	// Array of SSL certificates.
+	List map[string]SSLCertificateProperties `json:"certificates"`
+}
+
+// SSLCertificate represents a single SSL certificate.
+type SSLCertificate struct {
+	// Properties of a SSL certificate.
+	Properties SSLCertificateProperties `json:"certificate"`
+}
+
+// SSLCertificateProperties holds properties of a SSL certificate.
+// A SSL certificate can be retrieved and linked to a loadbalancer.
+type SSLCertificateProperties struct {
+	// The UUID of an object is always unique, and refers to a specific object.
+	ObjectUUID string `json:"object_uuid"`
+
+	// The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
+	Name string `json:"name"`
+
+	// The common domain name of the SSL certificate.
+	CommonName string `json:"common_name"`
+
+	// Defines the date and time the object was initially created.
+	CreateTime GSTime `json:"create_time"`
+
+	// Defines the date and time of the last object change.
+	ChangeTime GSTime `json:"change_time"`
+
+	// Status indicates the status of the object.
+	Status string `json:"status"`
+
+	// Defines the date after which the certificate does not valid.
+	NotValidAfter GSTime `json:"not_valid_after"`
+
+	// Defines a list of unique identifiers generated from the MD5, SHA-1, and SHA-256 fingerprints of the certificate.
+	Fingerprints FingerprintProperties `json:"fingerprints"`
+
+	// List of labels.
+	Labels []string `json:"labels"`
+}
+
+// FingerprintProperties holds properties of a list unique identifiers generated from the MD5, SHA-1, and SHA-256 fingerprints of the certificate.
+type FingerprintProperties struct {
+	// A unique identifier generated from the MD5 fingerprint of the certificate.
+	MD5 string `json:"md5"`
+
+	// A unique identifier generated from the SHA1 fingerprint of the certificate.
+	SHA1 string `json:"sha1"`
+
+	// A unique identifier generated from the SHA256 fingerprint of the certificate.
+	SHA256 string `json:"sha256"`
+}
+
+// SSLCertificateCreateRequest represent a payload of a request for creating a SSL certificate.
+type SSLCertificateCreateRequest struct {
+	// The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
+	Name string `json:"name"`
+
+	// The PEM-formatted private-key of the SSL certificate.
+	PrivateKey string `json:"private_key"`
+
+	// The PEM-formatted public SSL of the SSL certificate.
+	LeafCertificate string `json:"leaf_certificate"`
+
+	// The PEM-formatted full-chain between the certificate authority and the domain's SSL certificate.
+	CertificateChain string `json:"certificate_chain"`
+}
+
+// GetSSLCertificateList gets the list of available SSL certificates in the project.
+//
+// See: https://gridscale.io/en/api-documentation/index.html#operation/getCertificates
+func (c *Client) GetSSLCertificateList(ctx context.Context) ([]SSLCertificate, error) {
+	r := gsRequest{
+		uri:                 apiSSLCertificateBase,
+		method:              http.MethodGet,
+		skipCheckingRequest: true,
+	}
+
+	var response SSLCertificateList
+	var sslCerts []SSLCertificate
+	err := r.execute(ctx, *c, &response)
+	for _, properties := range response.List {
+		sslCerts = append(sslCerts, SSLCertificate{Properties: properties})
+	}
+	return sslCerts, err
+}
+
+// GetSSLCertificate gets a single SSL certificate.
+//
+// See: https://gridscale.io/en/api-documentation/index.html#operation/getCertificate
+func (c *Client) GetSSLCertificate(ctx context.Context, id string) (SSLCertificate, error) {
+	if !isValidUUID(id) {
+		return SSLCertificate{}, errors.New("'id' is invalid")
+	}
+	r := gsRequest{
+		uri:                 path.Join(apiSSLCertificateBase, id),
+		method:              http.MethodGet,
+		skipCheckingRequest: true,
+	}
+	var response SSLCertificate
+	err := r.execute(ctx, *c, &response)
+	return response, err
+}
+
+// CreateSSLCertificate creates a new SSL certificate.
+//
+// See: https://gridscale.io/en/api-documentation/index.html#operation/createCertificate
+func (c *Client) CreateSSLCertificate(ctx context.Context, body SSLCertificateCreateRequest) (CreateResponse, error) {
+	r := gsRequest{
+		uri:    apiSSLCertificateBase,
+		method: http.MethodPost,
+		body:   body,
+	}
+	var response CreateResponse
+	err := r.execute(ctx, *c, &response)
+	return response, err
+}
+
+// DeleteSSLCertificate removes a single SSL certificate.
+//
+// See: https://gridscale.io/en/api-documentation/index.html#operation/deleteCertificate
+func (c *Client) DeleteSSLCertificate(ctx context.Context, id string) error {
+	if !isValidUUID(id) {
+		return errors.New("'id' is invalid")
+	}
+	r := gsRequest{
+		uri:    path.Join(apiSSLCertificateBase, id),
+		method: http.MethodDelete,
+	}
+	return r.execute(ctx, *c, nil)
+}

--- a/ssl_certificate.go
+++ b/ssl_certificate.go
@@ -7,6 +7,14 @@ import (
 	"path"
 )
 
+// SSLCertificateOperator provides an interface for operations on SSL certificates.
+type SSLCertificateOperator interface {
+	GetSSLCertificateList(ctx context.Context) ([]SSLCertificate, error)
+	GetSSLCertificate(ctx context.Context, id string) (SSLCertificate, error)
+	CreateSSLCertificate(ctx context.Context, body SSLCertificateCreateRequest) (CreateResponse, error)
+	DeleteSSLCertificate(ctx context.Context, id string) error
+}
+
 // SSLCertificateList holds a list of SSL certificates.
 type SSLCertificateList struct {
 	// Array of SSL certificates.

--- a/ssl_certificate.go
+++ b/ssl_certificate.go
@@ -83,6 +83,9 @@ type SSLCertificateCreateRequest struct {
 
 	// The PEM-formatted full-chain between the certificate authority and the domain's SSL certificate.
 	CertificateChain string `json:"certificate_chain,omitempty"`
+
+	// List of labels.
+	Labels []string `json:"labels,omitempty"`
 }
 
 // GetSSLCertificateList gets the list of available SSL certificates in the project.

--- a/ssl_certificate.go
+++ b/ssl_certificate.go
@@ -82,7 +82,7 @@ type SSLCertificateCreateRequest struct {
 	LeafCertificate string `json:"leaf_certificate"`
 
 	// The PEM-formatted full-chain between the certificate authority and the domain's SSL certificate.
-	CertificateChain string `json:"certificate_chain"`
+	CertificateChain string `json:"certificate_chain,omitempty"`
 }
 
 // GetSSLCertificateList gets the list of available SSL certificates in the project.

--- a/ssl_certificate_test.go
+++ b/ssl_certificate_test.go
@@ -1,0 +1,153 @@
+package gsclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_GetSSLCertificateList(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	uri := apiSSLCertificateBase
+	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, http.MethodGet, request.Method)
+		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		fmt.Fprintf(writer, prepareSSLCertificateListHTTPGet())
+	})
+	res, err := client.GetSSLCertificateList(emptyCtx)
+	assert.Nil(t, err, "GetSSLCertificateList returned an error %v", err)
+	assert.Equal(t, 1, len(res))
+	assert.Equal(t, fmt.Sprintf("[%v]", getMockSSLCertificate("active")), fmt.Sprintf("%v", res))
+}
+
+func TestClient_GetSSLCertificate(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	uri := path.Join(apiSSLCertificateBase, dummyUUID)
+	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, http.MethodGet, request.Method)
+		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		fmt.Fprintf(writer, prepareSSLCertificateHTTPGet("active"))
+	})
+	for _, test := range uuidCommonTestCases {
+		res, err := client.GetSSLCertificate(emptyCtx, test.testUUID)
+		if test.isFailed {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err, "GetSSLCertificate returned an error %v", err)
+			assert.Equal(t, fmt.Sprintf("%v", getMockSSLCertificate("active")), fmt.Sprintf("%v", res))
+		}
+	}
+}
+
+func TestClient_SSLCertificate(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	var isFailed bool
+	uri := apiSSLCertificateBase
+	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, http.MethodPost, request.Method)
+		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		if isFailed {
+			writer.WriteHeader(400)
+		} else {
+			fmt.Fprintf(writer, prepareSSLCertificateCreateResponse())
+		}
+	})
+	for _, test := range commonSuccessFailTestCases {
+		isFailed = test.isFailed
+		response, err := client.CreateSSLCertificate(
+			emptyCtx,
+			SSLCertificateCreateRequest{
+				Name:            "test",
+				PrivateKey:      "-----BEGIN RSA PRIVATE KEY-----abc-----END RSA PRIVATE KEY-----",
+				LeafCertificate: "-----BEGIN CERTIFICATE-----abc-----END CERTIFICATE-----",
+			})
+		if isFailed {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err, "CreateSSLCertificate returned an error %v", err)
+			assert.Equal(t, fmt.Sprintf("%v", getMockSSLCertificateCreateResponse()), fmt.Sprintf("%s", response))
+		}
+	}
+}
+
+func TestClient_DeleteSSLCertificate(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	var isFailed bool
+	uri := path.Join(apiSSLCertificateBase, dummyUUID)
+	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		if isFailed {
+			writer.WriteHeader(400)
+		} else {
+			if request.Method == http.MethodDelete {
+				fmt.Fprintf(writer, "")
+			} else if request.Method == http.MethodGet {
+				writer.WriteHeader(404)
+			}
+		}
+	})
+	for _, serverTest := range commonSuccessFailTestCases {
+		isFailed = serverTest.isFailed
+		for _, test := range uuidCommonTestCases {
+			err := client.DeleteSSLCertificate(emptyCtx, test.testUUID)
+			if test.isFailed || isFailed {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err, "DeleteSSLCertificate returned an error %v", err)
+			}
+		}
+	}
+}
+
+func getMockSSLCertificate(status string) SSLCertificate {
+	mock := SSLCertificate{Properties: SSLCertificateProperties{
+		Name:          "test",
+		ObjectUUID:    dummyUUID,
+		Status:        status,
+		CreateTime:    dummyTime,
+		ChangeTime:    dummyTime,
+		Labels:        []string{"label"},
+		CommonName:    "www.example.com",
+		NotValidAfter: dummyTime,
+		Fingerprints: FingerprintProperties{
+			MD5:    "6F:92:07:C2:01:2A:AF:A2:0C:0F:2E:21:4A:10:DB:64",
+			SHA1:   "98:7D:24:03:E6:E3:B8:10:68:CD:89:C6:3A:78:66:3F:E2:61:A5:03",
+			SHA256: "13:4B:BF:D0:16:9E:7F:15:56:48:E6:E4:8E:38:6A:B6:E6:BE:84:4F:C4:6B:C6:4B:57:C0:41:22:2F:0A:C0:3A",
+		},
+	}}
+	return mock
+}
+
+func getMockSSLCertificateCreateResponse() CreateResponse {
+	mock := CreateResponse{
+		ObjectUUID:  dummyUUID,
+		RequestUUID: dummyRequestUUID,
+	}
+	return mock
+}
+
+func prepareSSLCertificateListHTTPGet() string {
+	key := getMockSSLCertificate("active")
+	res, _ := json.Marshal(key.Properties)
+	return fmt.Sprintf(`{"certificates": {"%s": %s}}`, dummyUUID, string(res))
+}
+
+func prepareSSLCertificateHTTPGet(status string) string {
+	key := getMockSSLCertificate(status)
+	res, _ := json.Marshal(key)
+	return string(res)
+}
+
+func prepareSSLCertificateCreateResponse() string {
+	response := getMockSSLCertificateCreateResponse()
+	res, _ := json.Marshal(response)
+	return string(res)
+}


### PR DESCRIPTION
Ref #194. Changes:
- Add SSL certificate CRUD operations.
- Add unit tests of SSL certificate.
- Add example of SSL certificate operations.
- Change `LetsencryptSSL` field in loadbalancer from `interface{}` to `*string` (because this field is string type and it is nullable).
- Add `CertificateUUID` field in loadbalancer, allow to use a custom certificate.