### PR TITLE
Add DEPRECATED notice to `CurrentPrice` field docs

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -89,7 +89,7 @@ type IPProperties struct {
 	// Total minutes the object has been running.
 	UsagesInMinutes float64 `json:"usage_in_minutes"`
 
-	// The price for the current period since the last bill.
+	// **DEPRECATED** The price for the current period since the last bill.
 	CurrentPrice float64 `json:"current_price"`
 
 	// List of labels.

--- a/isoimage.go
+++ b/isoimage.go
@@ -91,7 +91,7 @@ type ISOImageProperties struct {
 	// The capacity of an ISO image in GB.
 	Capacity int `json:"capacity"`
 
-	// The price for the current period since the last bill.
+	// **DEPRECATED** The price for the current period since the last bill.
 	CurrentPrice float64 `json:"current_price"`
 }
 

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -58,7 +58,7 @@ type LoadBalancerProperties struct {
 	// Status indicates the status of the object.
 	Status string `json:"status"`
 
-	// The price for the current period since the last bill.
+	// **DEPRECATED** The price for the current period since the last bill.
 	CurrentPrice float64 `json:"current_price"`
 
 	// The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters.

--- a/paas.go
+++ b/paas.go
@@ -70,7 +70,7 @@ type PaaSServiceProperties struct {
 	// Total minutes the object has been running.
 	UsageInMinutes int `json:"usage_in_minutes"`
 
-	// The price for the current period since the last bill.
+	// **DEPRECATED** The price for the current period since the last bill.
 	CurrentPrice float64 `json:"current_price"`
 
 	// Defines the date and time of the last object change.

--- a/server.go
+++ b/server.go
@@ -68,7 +68,7 @@ type ServerProperties struct {
 	// The power status of the server.
 	Power bool `json:"power"`
 
-	// The price for the current period since the last bill.
+	// **DEPRECATED** The price for the current period since the last bill.
 	CurrentPrice float64 `json:"current_price"`
 
 	// Which Availability-Zone the Server is placed.

--- a/snapshot.go
+++ b/snapshot.go
@@ -70,7 +70,7 @@ type StorageSnapshotProperties struct {
 	// this shows the product_no of the license (see the /prices endpoint for more details).
 	LicenseProductNo int `json:"license_product_no"`
 
-	// The price for the current period since the last bill.
+	// **DEPRECATED** The price for the current period since the last bill.
 	CurrentPrice float64 `json:"current_price"`
 
 	// Defines the date and time the object was initially created.

--- a/storage.go
+++ b/storage.go
@@ -64,7 +64,7 @@ type StorageProperties struct {
 	// Indicates the UUID of the last used template on this storage.
 	LastUsedTemplate string `json:"last_used_template"`
 
-	// The price for the current period since the last bill.
+	// **DEPRECATED** The price for the current period since the last bill.
 	CurrentPrice float64 `json:"current_price"`
 
 	// The capacity of a storage/ISO image/template/snapshot in GB.

--- a/template.go
+++ b/template.go
@@ -89,7 +89,7 @@ type TemplateProperties struct {
 	// Description of the template.
 	Description string `json:"description"`
 
-	// The price for the current period since the last bill.
+	// **DEPRECATED** The price for the current period since the last bill.
 	CurrentPrice float64 `json:"current_price"`
 
 	// The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters.


### PR DESCRIPTION
Ref #191. Temporarily add DEPRECATED notice to `CurrentPrice` field docs.