### PR TITLE
Correct service_template_uuid field in update PaaS request

### DIFF
--- a/paas.go
+++ b/paas.go
@@ -313,7 +313,7 @@ type PaaSServiceUpdateRequest struct {
 	ResourceLimits []ResourceLimit `json:"resource_limits,omitempty"`
 
 	// The template that you want to use in the service, you can find an available list at the /service_templates endpoint.
-	PaaSServiceTemplateUUID string `json:"paas_service_template_uuid,omitempty"`
+	PaaSServiceTemplateUUID string `json:"service_template_uuid,omitempty"`
 }
 
 // PaaSServiceMetrics represents a list of metrics of a PaaS service.


### PR DESCRIPTION
Ref #197. @itakouna and I decided to use `service_template_uuid` instead of `paas_service_template_uuid `. What changes:
- The json field name of `PaaSServiceTemplateUUID` is changed to `service_template_uuid`. The reasons are: The backward compatibility is guaranteed and the json field name can be easily changed in the future (in case `paas_service_template_uuid ` is used in PaaS Update).

I did test the change by upgrading a k8s cluster from v11.18 to v1.19 ✔️ 
