### PR TITLE
Fix PROTOCOL_ERROR

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,28 +2,26 @@ name: Go
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+        id: go
 
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
-      with:
-        go-version: ^1.13
-      id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      - name: Install dependencies
+        run: go get -v -t $(go list ./... | grep -v /examples)
 
-    - name: Install dependencies
-      run: go get -v -t $(go list ./... | grep -v /examples)
-
-    - name: Test
-      run: go test -v -cover $(go list ./... | grep -v /examples)
+      - name: Test
+        run: go test -v -cover $(go list ./... | grep -v /examples)

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package gsclient
 
 import (
+	"crypto/tls"
 	"net/http"
 	"os"
 	"runtime"
@@ -60,12 +61,16 @@ func NewConfiguration(apiURL string, uuid string, token string, debugMode, sync 
 	}
 
 	cfg := &Config{
-		apiURL:             apiURL,
-		userUUID:           uuid,
-		apiToken:           token,
-		userAgent:          "gsclient-go/" + version + " (" + runtime.GOOS + ")",
-		sync:               sync,
-		httpClient:         http.DefaultClient,
+		apiURL:    apiURL,
+		userUUID:  uuid,
+		apiToken:  token,
+		userAgent: "gsclient-go/" + version + " (" + runtime.GOOS + ")",
+		sync:      sync,
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				TLSNextProto: make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
+			},
+		},
 		delayInterval:      time.Duration(delayIntervalMilliSecs) * time.Millisecond,
 		maxNumberOfRetries: maxNumberOfRetries,
 	}
@@ -75,12 +80,16 @@ func NewConfiguration(apiURL string, uuid string, token string, debugMode, sync 
 // DefaultConfiguration creates a default configuration.
 func DefaultConfiguration(uuid string, token string) *Config {
 	cfg := &Config{
-		apiURL:             defaultAPIURL,
-		userUUID:           uuid,
-		apiToken:           token,
-		userAgent:          "gsclient-go/" + version + " (" + runtime.GOOS + ")",
-		sync:               true,
-		httpClient:         http.DefaultClient,
+		apiURL:    defaultAPIURL,
+		userUUID:  uuid,
+		apiToken:  token,
+		userAgent: "gsclient-go/" + version + " (" + runtime.GOOS + ")",
+		sync:      true,
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				TLSNextProto: make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
+			},
+		},
 		delayInterval:      time.Duration(defaultDelayIntervalMilliSecs) * time.Millisecond,
 		maxNumberOfRetries: defaultMaxNumberOfRetries,
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gridscale/gsclient-go/v3
 
-go 1.13
+go 1.16
 
 require (
 	github.com/google/uuid v1.2.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,14 +1,18 @@
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/google/uuid v1.2.0
+## explicit
 github.com/google/uuid
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/sirupsen/logrus v1.7.0
+## explicit
 github.com/sirupsen/logrus
 # github.com/stretchr/testify v1.7.0
+## explicit
 github.com/stretchr/testify/assert
 # golang.org/x/net v0.0.0-20210119194325-5f4716e94777
+## explicit
 golang.org/x/net/context
 # golang.org/x/sys v0.0.0-20201119102817-f84b799fce68
 golang.org/x/sys/internal/unsafeheader


### PR DESCRIPTION
There is a bug in go which caused the body of a HTTP2 upgraded request disappears during retry. The issue occasionally happens when concurrency is used. To solve this issue, I force the http client to use HTTP 1.1 explicitly (no HTTP2 upgrade). Furthermore, update golang to  v1.16 in go.mod file.