### PR TITLE
Fix handling of retry-able requests 429 and 503

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ config := gsclient.NewConfiguration(
             "API-token",
             false, //Set debug mode
             true, //Set sync mode
-            500, //Delay (in milliseconds) between requests
-            100, //Maximum number of retries
+            500, //Delay (in milliseconds) between requests (or retry 503 error code)
+            100, //Maximum number of retries when server returns 503 error code
         )
 client := gsclient.NewClient(config)
 ```

--- a/config.go
+++ b/config.go
@@ -52,8 +52,8 @@ var logger = logrus.Logger{
 //		+ debugMode bool: true => run client in debug mode.
 //		+ sync bool: true => client is in synchronous mode. The client will block until Create/Update/Delete processes.
 //		are completely finished. It is safer to set this parameter to `true`.
-//		+ delayIntervalMilliSecs int: delay (in milliseconds) between requests when checking request (or retry 5xx, 424 error code).
-//		+ maxNumberOfRetries int: number of retries when server returns 5xx, 424 error code.
+//		+ delayIntervalMilliSecs int: delay (in milliseconds) between requests when checking request (or retry 503 error code).
+//		+ maxNumberOfRetries int: number of retries when server returns 503 error code.
 func NewConfiguration(apiURL string, uuid string, token string, debugMode, sync bool,
 	delayIntervalMilliSecs, maxNumberOfRetries int) *Config {
 	if debugMode {

--- a/event_test.go
+++ b/event_test.go
@@ -3,9 +3,10 @@ package gsclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_GetEventList(t *testing.T) {
@@ -14,7 +15,7 @@ func TestClient_GetEventList(t *testing.T) {
 	uri := apiEventBase
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareEventListHTTPGet())
 	})
 	response, err := client.GetEventList(emptyCtx)

--- a/firewall_test.go
+++ b/firewall_test.go
@@ -3,10 +3,11 @@ package gsclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_GetFirewallList(t *testing.T) {
@@ -15,7 +16,7 @@ func TestClient_GetFirewallList(t *testing.T) {
 	uri := path.Join(apiFirewallBase)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareFirewallListHTTPGet("active"))
 	})
 	response, err := client.GetFirewallList(emptyCtx)
@@ -30,7 +31,7 @@ func TestClient_GetFirewall(t *testing.T) {
 	uri := path.Join(apiFirewallBase, dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareFirewallHTTPGet("active"))
 	})
 	for _, test := range uuidCommonTestCases {
@@ -51,7 +52,7 @@ func TestClient_CreateFirewall(t *testing.T) {
 	var isFailed bool
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -91,7 +92,7 @@ func TestClient_UpdateFirewall(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiFirewallBase, dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -138,7 +139,7 @@ func TestClient_DeleteFirewall(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiFirewallBase, dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -168,7 +169,7 @@ func TestClient_GetFirewallEventList(t *testing.T) {
 	uri := path.Join(apiFirewallBase, dummyUUID, "events")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareEventListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {

--- a/ip_test.go
+++ b/ip_test.go
@@ -3,10 +3,11 @@ package gsclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_GetIPList(t *testing.T) {
@@ -15,7 +16,7 @@ func TestClient_GetIPList(t *testing.T) {
 	uri := apiIPBase
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareIPListHTTPGet("active"))
 	})
 	res, err := client.GetIPList(emptyCtx)
@@ -30,7 +31,7 @@ func TestClient_GetIP(t *testing.T) {
 	uri := path.Join(apiIPBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareIPHTTPGet("active"))
 	})
 	for _, test := range uuidCommonTestCases {
@@ -51,7 +52,7 @@ func TestClient_CreateIP(t *testing.T) {
 	uri := apiIPBase
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -83,7 +84,7 @@ func TestClient_UpdateIP(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiIPBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -120,7 +121,7 @@ func TestClient_DeleteIP(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiIPBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -150,7 +151,7 @@ func TestClient_GetIPEventList(t *testing.T) {
 	uri := path.Join(apiIPBase, dummyUUID, "events")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareEventListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -173,7 +174,7 @@ func TestClient_GetIPVersion(t *testing.T) {
 	uri := path.Join(apiIPBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -197,7 +198,7 @@ func TestClient_GetIPsByLocation(t *testing.T) {
 	uri := path.Join(apiLocationBase, dummyUUID, "ips")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareIPListHTTPGet("active"))
 	})
 	for _, test := range uuidCommonTestCases {
@@ -218,7 +219,7 @@ func TestClient_GetDeletedIPs(t *testing.T) {
 	uri := path.Join(apiDeletedBase, "ips")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareDeletedIPListHTTPGet("deleted"))
 	})
 	res, err := client.GetDeletedIPs(emptyCtx)

--- a/isoimage_test.go
+++ b/isoimage_test.go
@@ -3,10 +3,11 @@ package gsclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_GetISOImageList(t *testing.T) {
@@ -15,7 +16,7 @@ func TestClient_GetISOImageList(t *testing.T) {
 	uri := path.Join(apiISOBase)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareISOImageHTTPGetList("active"))
 	})
 	res, err := client.GetISOImageList(emptyCtx)
@@ -30,7 +31,7 @@ func TestClient_GetISOImage(t *testing.T) {
 	uri := path.Join(apiISOBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareISOImageHTTPGet("active"))
 	})
 	for _, test := range uuidCommonTestCases {
@@ -51,7 +52,7 @@ func TestClient_CreateISOImage(t *testing.T) {
 	var isFailed bool
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -82,7 +83,7 @@ func TestClient_UpdateISOImage(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiISOBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -118,7 +119,7 @@ func TestClient_DeleteISOImage(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiISOBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -148,7 +149,7 @@ func TestClient_GetISOImageEventList(t *testing.T) {
 	uri := path.Join(apiISOBase, dummyUUID, "events")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(writer, prepareEventListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -169,7 +170,7 @@ func TestClient_GetISOImagesByLocation(t *testing.T) {
 	uri := path.Join(apiLocationBase, dummyUUID, "isoimages")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareISOImageHTTPGetList("active"))
 	})
 	for _, test := range uuidCommonTestCases {
@@ -190,7 +191,7 @@ func TestClient_GetDeletedISOImages(t *testing.T) {
 	uri := path.Join(apiDeletedBase, "isoimages")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareDeletedISOImageHTTPGetList("deleted"))
 	})
 	res, err := client.GetDeletedISOImages(emptyCtx)

--- a/label_test.go
+++ b/label_test.go
@@ -26,7 +26,7 @@ func TestClient_GetLabelList(t *testing.T) {
 	uri := apiLabelBase
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareLabelListHTTPGet("test"))
 	})
 	res, err := client.GetLabelList(emptyCtx)

--- a/loadbalancer_test.go
+++ b/loadbalancer_test.go
@@ -19,7 +19,7 @@ func TestClient_CreateLoadBalancer(t *testing.T) {
 	uri := path.Join(apiLoadBalancerBase)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, http.MethodPost)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -57,7 +57,7 @@ func TestClient_GetLoadBalancer(t *testing.T) {
 	expectedObject := getMockLoadbalancer("active")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, http.MethodGet)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareLoadBalancerHTTPGetResponse("active"))
 	})
 	for _, test := range uuidCommonTestCases {
@@ -79,7 +79,7 @@ func TestClient_GetLoadBalancerList(t *testing.T) {
 	expectedObjects := getMockLoadbalancer("active")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, http.MethodGet)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareLoadBalancerHTTPListResponse("active"))
 	})
 	loadbalancers, err := client.GetLoadBalancerList(emptyCtx)
@@ -94,7 +94,7 @@ func TestClient_UpdateLoadBalancer(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiLoadBalancerBase, dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -133,7 +133,7 @@ func TestClient_DeleteLoadBalancer(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiLoadBalancerBase, dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -165,7 +165,7 @@ func TestClient_GetLoadBalancerEventList(t *testing.T) {
 	expectedObjects := getMockEvent()
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, http.MethodGet)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareEventListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {

--- a/location_test.go
+++ b/location_test.go
@@ -16,7 +16,7 @@ func TestClient_GetLocationList(t *testing.T) {
 	uri := apiLocationBase
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareLocationListHTTPGet())
 	})
 	res, err := client.GetLocationList(emptyCtx)
@@ -31,7 +31,7 @@ func TestClient_GetLocation(t *testing.T) {
 	uri := path.Join(apiLocationBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareLocationHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {

--- a/marketplace_application_test.go
+++ b/marketplace_application_test.go
@@ -16,7 +16,7 @@ func TestClient_GetMarketplaceApplicationList(t *testing.T) {
 	uri := apiMarketplaceApplicationBase
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareMarketplaceApplicationListHTTPGet())
 	})
 	response, err := client.GetMarketplaceApplicationList(emptyCtx)
@@ -31,7 +31,7 @@ func TestClient_GetMarketplaceApplication(t *testing.T) {
 	uri := path.Join(apiMarketplaceApplicationBase, dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareMarketplaceApplicationHTTPGet("active"))
 	})
 	for _, test := range uuidCommonTestCases {
@@ -52,7 +52,7 @@ func TestClient_CreateMarketplaceApplication(t *testing.T) {
 	uri := apiMarketplaceApplicationBase
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -90,7 +90,7 @@ func TestClient_ImportMarketplaceApplication(t *testing.T) {
 	uri := apiMarketplaceApplicationBase
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -119,7 +119,7 @@ func TestClient_UpdateMarketplaceApplication(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiMarketplaceApplicationBase, dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -161,7 +161,7 @@ func TestClient_DeleteMarketplaceApplication(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiMarketplaceApplicationBase, dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -191,7 +191,7 @@ func TestClient_GetMarketplaceApplicationEventList(t *testing.T) {
 	uri := path.Join(apiMarketplaceApplicationBase, dummyUUID, "events")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareEventListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {

--- a/network_test.go
+++ b/network_test.go
@@ -3,10 +3,11 @@ package gsclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_GetNetworkList(t *testing.T) {
@@ -15,7 +16,7 @@ func TestClient_GetNetworkList(t *testing.T) {
 	uri := apiNetworkBase
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareNetworkListHTTPGet(true, "active"))
 	})
 	res, err := client.GetNetworkList(emptyCtx)
@@ -30,7 +31,7 @@ func TestClient_GetNetwork(t *testing.T) {
 	uri := path.Join(apiNetworkBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareNetworkHTTPGet("active"))
 	})
 	for _, test := range uuidCommonTestCases {
@@ -51,7 +52,7 @@ func TestClient_CreateNetwork(t *testing.T) {
 	uri := apiNetworkBase
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -83,7 +84,7 @@ func TestClient_UpdateNetwork(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiNetworkBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -119,7 +120,7 @@ func TestClient_DeleteNetwork(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiNetworkBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -149,7 +150,7 @@ func TestClient_GetNetworkEventList(t *testing.T) {
 	uri := path.Join(apiNetworkBase, dummyUUID, "events")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareEventListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -173,7 +174,7 @@ func TestClient_GetNetworkPublic(t *testing.T) {
 	uri := apiNetworkBase
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -201,7 +202,7 @@ func TestClient_GetNetworksByLocation(t *testing.T) {
 	uri := path.Join(apiLocationBase, dummyUUID, "networks")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareNetworkListHTTPGet(true, "active"))
 	})
 	for _, test := range uuidCommonTestCases {
@@ -222,7 +223,7 @@ func TestClient_GetDeletedNetworks(t *testing.T) {
 	uri := path.Join(apiDeletedBase, "networks")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareDeletedNetworkListHTTPGet("active"))
 	})
 	res, err := client.GetDeletedNetworks(emptyCtx)

--- a/objectstorage_test.go
+++ b/objectstorage_test.go
@@ -3,10 +3,11 @@ package gsclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_GetObjectStorageAccessKeyList(t *testing.T) {
@@ -15,7 +16,7 @@ func TestClient_GetObjectStorageAccessKeyList(t *testing.T) {
 	uri := path.Join(apiObjectStorageBase, "access_keys")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareObjectStorageAccessKeyListHTTPGet())
 	})
 
@@ -31,7 +32,7 @@ func TestClient_GetObjectStorageAccessKey(t *testing.T) {
 	uri := path.Join(apiObjectStorageBase, "access_keys", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareObjectStorageAccessKeyHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -52,7 +53,7 @@ func TestClient_CreateObjectStorageAccessKey(t *testing.T) {
 	uri := path.Join(apiObjectStorageBase, "access_keys")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -77,7 +78,7 @@ func TestClient_DeleteObjectStorageAccessKey(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiObjectStorageBase, "access_keys", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -107,7 +108,7 @@ func TestClient_GetObjectStorageBucketList(t *testing.T) {
 	uri := path.Join(apiObjectStorageBase, "buckets")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareObjectStorageBucketListHTTPGet())
 	})
 

--- a/paas_test.go
+++ b/paas_test.go
@@ -17,7 +17,7 @@ func TestClient_GetPaaSServiceList(t *testing.T) {
 	expectedObj := getMockPaaSService("active")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, http.MethodGet)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, preparePaaSHTTPGetListResponse("active"))
 	})
 	paasList, err := client.GetPaaSServiceList(emptyCtx)
@@ -33,7 +33,7 @@ func TestClient_GetPaaSService(t *testing.T) {
 	expectedObj := getMockPaaSService("active")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, http.MethodGet)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, preparePaaSHTTPGetResponse("active"))
 	})
 	for _, test := range uuidCommonTestCases {
@@ -55,7 +55,7 @@ func TestClient_CreatePaaSService(t *testing.T) {
 	expectedRespObj := getMockPaaSServiceCreateResponse()
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, http.MethodPost)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -95,7 +95,7 @@ func TestClient_UpdatePaaSService(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiPaaSBase, "services", dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -140,7 +140,7 @@ func TestClient_DeletePaaSService(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiPaaSBase, "services", dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -170,7 +170,7 @@ func TestClient_GetPaaSServiceMetrics(t *testing.T) {
 	uri := path.Join(apiPaaSBase, "services", dummyUUID, "metrics")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, request.Method, http.MethodGet)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, preparePaaSHTTPGetMetricsResponse())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -191,7 +191,7 @@ func TestClient_RenewK8sCredentials(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiPaaSBase, "services", dummyUUID, "renew_credentials")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -220,7 +220,7 @@ func TestClient_GetPaaSTemplateList(t *testing.T) {
 	uri := path.Join(apiPaaSBase, "service_templates")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, request.Method, http.MethodGet)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, preparePaaSHTTPGetTemplatesResponse())
 	})
 	res, err := client.GetPaaSTemplateList(emptyCtx)
@@ -235,7 +235,7 @@ func TestClient_GetPaaSSecurityZoneList(t *testing.T) {
 	uri := path.Join(apiPaaSBase, "security_zones")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, request.Method, http.MethodGet)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, preparePaaSHTTPGetSecurityZoneList("active"))
 	})
 	res, err := client.GetPaaSSecurityZoneList(emptyCtx)
@@ -251,7 +251,7 @@ func TestClient_CreatePaaSSecurityZone(t *testing.T) {
 	uri := path.Join(apiPaaSBase, "security_zones")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, request.Method, http.MethodPost)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -280,7 +280,7 @@ func TestClient_GetPaaSSecurityZone(t *testing.T) {
 	uri := path.Join(apiPaaSBase, "security_zones", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, request.Method, http.MethodGet)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, preparePaaSHTTPGetSecurityZone("active"))
 	})
 	for _, test := range uuidCommonTestCases {
@@ -300,7 +300,7 @@ func TestClient_UpdatePaaSSecurityZone(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiPaaSBase, "security_zones", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -336,7 +336,7 @@ func TestClient_DeletePaaSSecurityZone(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiPaaSBase, "security_zones", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -367,7 +367,7 @@ func TestClient_GetDeletedPaaSServices(t *testing.T) {
 	expectedObj := getMockPaaSService("active")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, http.MethodGet)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareDeletedPaaSHTTPGetListResponse("active"))
 	})
 	paasList, err := client.GetDeletedPaaSServices(emptyCtx)

--- a/request.go
+++ b/request.go
@@ -73,7 +73,7 @@ func (r RequestError) Error() string {
 
 const (
 	requestUUIDHeader           = "X-Request-Id"
-	requestRateLimitResetHeader = "ratelimit-reset"
+	requestRateLimitResetHeader = "Ratelimit-Reset"
 	retryAfterHeader            = "Retry-After"
 )
 

--- a/request.go
+++ b/request.go
@@ -72,9 +72,9 @@ func (r RequestError) Error() string {
 }
 
 const (
-	requestUUIDHeaderParam           = "X-Request-Id"
-	requestRateLimitResetHeaderParam = "ratelimit-reset"
-	requestRetryAfteHeaderParam      = "Retry-After"
+	requestUUIDHeader           = "X-Request-Id"
+	requestRateLimitResetHeader = "ratelimit-reset"
+	retryAfterHeader            = "Retry-After"
 )
 
 // This function takes the client and a struct and then adds the result to the given struct if possible.
@@ -214,7 +214,7 @@ func (r *gsRequest) retryHTTPRequest(ctx context.Context, cfg *Config) (string, 
 		defer resp.Body.Close()
 
 		statusCode := resp.StatusCode
-		requestUUID = resp.Header.Get(requestUUIDHeaderParam)
+		requestUUID = resp.Header.Get(requestUUIDHeader)
 		responseBodyBytes, err = ioutil.ReadAll(resp.Body)
 		if err != nil {
 			logger.Errorf("Error while reading the response's body: %v", err)
@@ -234,7 +234,7 @@ func (r *gsRequest) retryHTTPRequest(ctx context.Context, cfg *Config) (string, 
 			switch statusCode {
 			case http.StatusServiceUnavailable:
 				// Get the delay (in second) for the next retry
-				delayDurationStr := resp.Header.Get(requestRetryAfteHeaderParam)
+				delayDurationStr := resp.Header.Get(retryAfterHeader)
 				delayDuration, err := strconv.Atoi(delayDurationStr)
 				if err != nil { // If there is no valid "Retry-After", do normal retry.
 					return true, errorMessage
@@ -249,7 +249,7 @@ func (r *gsRequest) retryHTTPRequest(ctx context.Context, cfg *Config) (string, 
 
 			case http.StatusTooManyRequests: // If status code is 429, that means we reach the rate limit.
 				// Get the time that the rate limit will be reset.
-				rateLimitResetTimestamp := resp.Header.Get(requestRateLimitResetHeaderParam)
+				rateLimitResetTimestamp := resp.Header.Get(requestRateLimitResetHeader)
 				// Get the delay time.
 				delayMs, err := getDelayTimeInMsFromTimestampStr(rateLimitResetTimestamp)
 				if err != nil {

--- a/request.go
+++ b/request.go
@@ -266,7 +266,7 @@ func (r *gsRequest) retryHTTPRequest(ctx context.Context, cfg *Config) (string, 
 				// Recursive retryHTTPRequest.
 				requestUUID, responseBodyBytes, err = r.retryHTTPRequest(ctx, cfg)
 				// Because of the recursive retryHTTPRequest, no need to retry here.
-				return false, errorMessage
+				return false, err
 			}
 			// If the error is not retryable.
 			logger.Errorf(

--- a/request_test.go
+++ b/request_test.go
@@ -71,7 +71,7 @@ var postNetworkErrorTests = []networkTestCase{
 
 var apiErrorTests = []apiTestCase{
 	{
-		name:          "retry the request in case of API error with status code 500",
+		name:          "retry the request in case of API error with status code 503",
 		statusCode:    503,
 		dummyUUID:     "690de890-13c0-4e76-8a01-e10ba8786e53",
 		expectedError: "Status code: %d. Error: Maximum number of re-tries has been exhausted with error: no error message received from server. Request UUID: %s.",

--- a/request_test.go
+++ b/request_test.go
@@ -72,20 +72,8 @@ var postNetworkErrorTests = []networkTestCase{
 var apiErrorTests = []apiTestCase{
 	{
 		name:          "retry the request in case of API error with status code 500",
-		statusCode:    500,
+		statusCode:    503,
 		dummyUUID:     "690de890-13c0-4e76-8a01-e10ba8786e53",
-		expectedError: "Status code: %d. Error: Maximum number of re-tries has been exhausted with error: no error message received from server. Request UUID: %s.",
-	},
-	{
-		name:          "retry the request in case of API error with status code 424",
-		statusCode:    424,
-		dummyUUID:     "690de890-13c0-4e76-8a01-e10ba8786e54",
-		expectedError: "Status code: %d. Error: Maximum number of re-tries has been exhausted with error: no error message received from server. Request UUID: %s.",
-	},
-	{
-		name:          "retry the request in case of API error with status code 409",
-		statusCode:    409,
-		dummyUUID:     "690de890-13c0-4e76-8a01-e10ba8786e55",
 		expectedError: "Status code: %d. Error: Maximum number of re-tries has been exhausted with error: no error message received from server. Request UUID: %s.",
 	},
 }

--- a/request_test.go
+++ b/request_test.go
@@ -122,7 +122,7 @@ func TestRequestGet_APIErrors(t *testing.T) {
 	for _, test := range apiErrorTests {
 		uri := path.Join(apiServerBase, test.dummyUUID)
 		mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+			w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 			w.WriteHeader(test.statusCode)
 		})
 		_, err := client.GetServer(emptyCtx, test.dummyUUID)
@@ -136,7 +136,7 @@ func TestRequestPatch_APIErrors(t *testing.T) {
 	for _, test := range apiErrorTests {
 		uri := path.Join(apiServerBase, test.dummyUUID)
 		mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+			w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 			w.WriteHeader(test.statusCode)
 		})
 		err := client.UpdateServer(
@@ -158,7 +158,7 @@ func TestRequestDelete_APIErrors(t *testing.T) {
 	for _, test := range apiErrorTests {
 		uri := path.Join(apiServerBase, test.dummyUUID)
 		mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+			w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 			w.WriteHeader(test.statusCode)
 		})
 		err := client.DeleteServer(emptyCtx, test.dummyUUID)

--- a/request_test.go
+++ b/request_test.go
@@ -192,39 +192,6 @@ func Test_prepareHTTPRequest(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func Test_isErrorHTTPCodeRetryable(t *testing.T) {
-	type testCase struct {
-		code        int
-		isRetryable bool
-	}
-	testCases := []testCase{
-		{
-			500,
-			true,
-		},
-		{
-			424,
-			true,
-		},
-		{
-			429,
-			true,
-		},
-		{
-			409,
-			true,
-		},
-		{
-			404,
-			false,
-		},
-	}
-	for _, test := range testCases {
-		isRetryable := isErrorHTTPCodeRetryable(test.code)
-		assert.Equal(t, test.isRetryable, isRetryable)
-	}
-}
-
 func Test_getDelayTimeInMsFromTimestampStr(t *testing.T) {
 	type testCase struct {
 		successful   bool

--- a/server_test.go
+++ b/server_test.go
@@ -291,8 +291,8 @@ func TestClient_ShutdownServer(t *testing.T) {
 					writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
 					if retries < 5 {
 						retries++
-						writer.WriteHeader(http.StatusInternalServerError)
-						writer.Write([]byte("☄ HTTP status code returned!"))
+						writer.WriteHeader(http.StatusServiceUnavailable)
+						writer.Write([]byte("☄ HTTP status code 503 returned!"))
 						return
 					}
 					power = false
@@ -319,8 +319,8 @@ func TestClient_ShutdownServer(t *testing.T) {
 				mux.HandleFunc(uri+"/shutdown", func(writer http.ResponseWriter, request *http.Request) {
 					assert.Equal(t, http.MethodPatch, request.Method)
 					writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
-					writer.WriteHeader(http.StatusInternalServerError)
-					writer.Write([]byte("☄ HTTP status code returned!"))
+					writer.WriteHeader(http.StatusServiceUnavailable)
+					writer.Write([]byte("☄ HTTP status code 503 returned!"))
 				})
 				mux.HandleFunc(uri+"/power", func(writer http.ResponseWriter, request *http.Request) {
 					assert.Equal(t, http.MethodPatch, request.Method)
@@ -330,7 +330,7 @@ func TestClient_ShutdownServer(t *testing.T) {
 				})
 				err := client.ShutdownServer(emptyCtx, dummyUUID)
 				assert.Contains(t, fmt.Sprintf("%v", err),
-					fmt.Sprintf("Status code: 500. Error: Maximum number of re-tries has been exhausted with error: no error message received from server. Request UUID: %s.",
+					fmt.Sprintf("Status code: 503. Error: Maximum number of re-tries has been exhausted with error: no error message received from server. Request UUID: %s.",
 						dummyRequestUUID), "ShutdownServer returned an error with status code 500")
 				server.Close()
 			}

--- a/server_test.go
+++ b/server_test.go
@@ -16,7 +16,7 @@ func TestClient_GetServerList(t *testing.T) {
 	uri := apiServerBase
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(writer, prepareServerListHTTPGet("active"))
 	})
 	res, err := client.GetServerList(emptyCtx)
@@ -31,7 +31,7 @@ func TestClient_GetServer(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(writer, prepareServerHTTPGet(true, "active"))
 	})
 	for _, test := range uuidCommonTestCases {
@@ -52,7 +52,7 @@ func TestClient_CreateServer(t *testing.T) {
 	uri := apiServerBase
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -87,7 +87,7 @@ func TestClient_UpdateServer(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiServerBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -126,7 +126,7 @@ func TestClient_DeleteServer(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiServerBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -156,7 +156,7 @@ func TestClient_GetServerEventList(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "events")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(writer, prepareEventListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -177,7 +177,7 @@ func TestClient_GetServerMetricList(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "metrics")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(writer, prepareServerMetricListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -198,7 +198,7 @@ func TestClient_IsServerOn(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(writer, prepareServerHTTPGet(true, "active"))
 	})
 	isOn, err := client.IsServerOn(emptyCtx, dummyUUID)
@@ -213,12 +213,12 @@ func TestClient_setServerPowerState(t *testing.T) {
 		power := true
 		mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 			assert.Equal(t, http.MethodGet, request.Method)
-			writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+			writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 			fmt.Fprint(writer, prepareServerHTTPGet(power, "active"))
 		})
 		mux.HandleFunc(uri+"/power", func(writer http.ResponseWriter, request *http.Request) {
 			assert.Equal(t, http.MethodPatch, request.Method)
-			writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+			writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 			power = false
 			fmt.Fprint(writer, "")
 		})
@@ -235,12 +235,12 @@ func TestClient_StartServer(t *testing.T) {
 		power := false
 		mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 			assert.Equal(t, http.MethodGet, request.Method)
-			writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+			writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 			fmt.Fprint(writer, prepareServerHTTPGet(power, "active"))
 		})
 		mux.HandleFunc(uri+"/power", func(writer http.ResponseWriter, request *http.Request) {
 			assert.Equal(t, http.MethodPatch, request.Method)
-			writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+			writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 			power = true
 			fmt.Fprint(writer, "")
 		})
@@ -257,12 +257,12 @@ func TestClient_StopServer(t *testing.T) {
 		power := true
 		mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 			assert.Equal(t, http.MethodGet, request.Method)
-			writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+			writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 			fmt.Fprint(writer, prepareServerHTTPGet(power, "active"))
 		})
 		mux.HandleFunc(uri+"/power", func(writer http.ResponseWriter, request *http.Request) {
 			assert.Equal(t, http.MethodPatch, request.Method)
-			writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+			writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 			power = false
 			fmt.Fprint(writer, "")
 		})
@@ -283,12 +283,12 @@ func TestClient_ShutdownServer(t *testing.T) {
 				retries := 0
 				mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 					assert.Equal(t, http.MethodGet, request.Method)
-					writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+					writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 					fmt.Fprint(writer, prepareServerHTTPGet(power, "active"))
 				})
 				mux.HandleFunc(uri+"/shutdown", func(writer http.ResponseWriter, request *http.Request) {
 					assert.Equal(t, http.MethodPatch, request.Method)
-					writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+					writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 					if retries < 5 {
 						retries++
 						writer.WriteHeader(http.StatusServiceUnavailable)
@@ -300,7 +300,7 @@ func TestClient_ShutdownServer(t *testing.T) {
 				})
 				mux.HandleFunc(uri+"/power", func(writer http.ResponseWriter, request *http.Request) {
 					assert.Equal(t, http.MethodPatch, request.Method)
-					writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+					writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 					power = false
 					fmt.Fprint(writer, "")
 				})
@@ -313,18 +313,18 @@ func TestClient_ShutdownServer(t *testing.T) {
 				power := true
 				mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 					assert.Equal(t, http.MethodGet, request.Method)
-					writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+					writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 					fmt.Fprint(writer, prepareServerHTTPGet(power, "active"))
 				})
 				mux.HandleFunc(uri+"/shutdown", func(writer http.ResponseWriter, request *http.Request) {
 					assert.Equal(t, http.MethodPatch, request.Method)
-					writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+					writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 					writer.WriteHeader(http.StatusServiceUnavailable)
 					writer.Write([]byte("☄ HTTP status code 503 returned!"))
 				})
 				mux.HandleFunc(uri+"/power", func(writer http.ResponseWriter, request *http.Request) {
 					assert.Equal(t, http.MethodPatch, request.Method)
-					writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+					writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 					power = false
 					fmt.Fprint(writer, "")
 				})
@@ -344,7 +344,7 @@ func TestClient_GetServersByLocation(t *testing.T) {
 	uri := path.Join(apiLocationBase, dummyUUID, "servers")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(writer, prepareServerListHTTPGet("active"))
 	})
 	for _, test := range uuidCommonTestCases {
@@ -365,7 +365,7 @@ func TestClient_GetDeletedServers(t *testing.T) {
 	uri := path.Join(apiDeletedBase, "servers")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(writer, prepareDeletedServerListHTTPGet("active"))
 	})
 	res, err := client.GetDeletedServers(emptyCtx)
@@ -380,7 +380,7 @@ func TestClient_waitForServerPowerStatus(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareServerHTTPGet(true, "active"))
 	})
 	err := client.waitForServerPowerStatus(emptyCtx, dummyUUID, true)

--- a/serverip_test.go
+++ b/serverip_test.go
@@ -3,10 +3,11 @@ package gsclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_GetServerIPList(t *testing.T) {
@@ -15,7 +16,7 @@ func TestClient_GetServerIPList(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "ips")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareServerIPListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -36,7 +37,7 @@ func TestClient_GetServerIP(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "ips", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareServerIPHTTPGet())
 	})
 	for _, testServerID := range uuidCommonTestCases {
@@ -59,7 +60,7 @@ func TestClient_CreateServerIP(t *testing.T) {
 	var isFailed bool
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -93,7 +94,7 @@ func TestClient_DeleteServerIP(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiServerBase, dummyUUID, "ips", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -125,7 +126,7 @@ func TestClient_LinkIP(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "ips")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(writer, "")
 	})
 	err := client.LinkIP(emptyCtx, dummyUUID, dummyUUID)
@@ -137,7 +138,7 @@ func TestClient_UnlinkIP(t *testing.T) {
 	defer server.Close()
 	uri := path.Join(apiServerBase, dummyUUID, "ips", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if request.Method == http.MethodDelete {
 			fmt.Fprintf(writer, "")
 		} else if request.Method == http.MethodGet {

--- a/serverisoimage_test.go
+++ b/serverisoimage_test.go
@@ -3,10 +3,11 @@ package gsclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_GetServerIsoImageList(t *testing.T) {
@@ -15,7 +16,7 @@ func TestClient_GetServerIsoImageList(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "isoimages")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareServerIsoImageListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -36,7 +37,7 @@ func TestClient_GetServerIsoImage(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "isoimages", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareServerIsoImageHTTPGet())
 	})
 	for _, testServerID := range uuidCommonTestCases {
@@ -59,7 +60,7 @@ func TestClient_CreateServerIsoImage(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "isoimages")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -92,7 +93,7 @@ func TestClient_UpdateServerIsoImage(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "isoimages", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPatch, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(writer, "")
 	})
 	for _, testServerID := range uuidCommonTestCases {
@@ -121,7 +122,7 @@ func TestClient_DeleteServerIsoImage(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiServerBase, dummyUUID, "isoimages", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -153,7 +154,7 @@ func TestClient_LinkIsoImage(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "isoimages")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(writer, "")
 	})
 	err := client.LinkIsoImage(emptyCtx, dummyUUID, dummyUUID)
@@ -166,7 +167,7 @@ func TestClient_UnlinkIsoImage(t *testing.T) {
 	defer server.Close()
 	uri := path.Join(apiServerBase, dummyUUID, "isoimages", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if request.Method == http.MethodDelete {
 			fmt.Fprintf(writer, "")
 		} else if request.Method == http.MethodGet {

--- a/servernetwork_test.go
+++ b/servernetwork_test.go
@@ -3,10 +3,11 @@ package gsclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_GetServerNetworkList(t *testing.T) {
@@ -15,7 +16,7 @@ func TestClient_GetServerNetworkList(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "networks")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareServerNetworkListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -36,7 +37,7 @@ func TestClient_GetServerNetwork(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "networks", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareServerNetworkHTTPGet())
 	})
 	for _, testServerID := range uuidCommonTestCases {
@@ -59,7 +60,7 @@ func TestClient_CreateServerNetwork(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "networks")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -96,7 +97,7 @@ func TestClient_UpdateServerNetwork(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "networks", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPatch, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(writer, "")
 	})
 	for _, testServerID := range uuidCommonTestCases {
@@ -125,7 +126,7 @@ func TestClient_DeleteServerNetwork(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiServerBase, dummyUUID, "networks", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -157,7 +158,7 @@ func TestClient_LinkNetwork(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "networks")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 	})
 	err := client.LinkNetwork(emptyCtx, dummyUUID, dummyUUID, dummyUUID, false, 1, nil, nil)
 	assert.Nil(t, err, "LinkNetwork returned an error %v", err)
@@ -168,7 +169,7 @@ func TestClient_UnlinkNetwork(t *testing.T) {
 	defer server.Close()
 	uri := path.Join(apiServerBase, dummyUUID, "networks", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if request.Method == http.MethodDelete {
 			fmt.Fprintf(writer, "")
 		} else if request.Method == http.MethodGet {

--- a/serverstorage_test.go
+++ b/serverstorage_test.go
@@ -3,10 +3,11 @@ package gsclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_GetServerStorageList(t *testing.T) {
@@ -15,7 +16,7 @@ func TestClient_GetServerStorageList(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "storages")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareServerStorageListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -36,7 +37,7 @@ func TestClient_GetServerStorage(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "storages", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareServerStorageHTTPGet())
 	})
 	for _, testServerID := range uuidCommonTestCases {
@@ -59,7 +60,7 @@ func TestClient_CreateServerStorage(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "storages")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -93,7 +94,7 @@ func TestClient_UpdateServerStorage(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "storages", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPatch, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(writer, "")
 	})
 	for _, testServerID := range uuidCommonTestCases {
@@ -121,7 +122,7 @@ func TestClient_DeleteServerStorage(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiServerBase, dummyUUID, "storages", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -153,7 +154,7 @@ func TestClient_LinkStorage(t *testing.T) {
 	uri := path.Join(apiServerBase, dummyUUID, "storages")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(writer, "")
 	})
 	err := client.LinkStorage(emptyCtx, dummyUUID, dummyUUID, true)
@@ -166,7 +167,7 @@ func TestClient_UnlinkStorage(t *testing.T) {
 	defer server.Close()
 	uri := path.Join(apiServerBase, dummyUUID, "storages", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if request.Method == http.MethodDelete {
 			fmt.Fprintf(writer, "")
 		} else if request.Method == http.MethodGet {

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -3,10 +3,11 @@ package gsclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_GetStorageSnapshotList(t *testing.T) {
@@ -15,7 +16,7 @@ func TestClient_GetStorageSnapshotList(t *testing.T) {
 	uri := path.Join(apiStorageBase, dummyUUID, "snapshots")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareStorageSnapshotListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -36,7 +37,7 @@ func TestClient_GetStorageSnapshot(t *testing.T) {
 	uri := path.Join(apiStorageBase, dummyUUID, "snapshots", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareStorageSnapshotHTTPGet("active"))
 	})
 	for _, testStorageID := range uuidCommonTestCases {
@@ -59,7 +60,7 @@ func TestClient_CreateStorageSnapshot(t *testing.T) {
 	uri := path.Join(apiStorageBase, dummyUUID, "snapshots")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -93,7 +94,7 @@ func TestClient_UpdateStorageSnapshot(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiStorageBase, dummyUUID, "snapshots", dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -132,7 +133,7 @@ func TestClient_DeleteStorageSnapshot(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiStorageBase, dummyUUID, "snapshots", dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -164,7 +165,7 @@ func TestClient_RollbackStorage(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiStorageBase, dummyUUID, "snapshots", dummyUUID, "rollback")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -192,7 +193,7 @@ func TestClient_ExportStorageSnapshotToS3(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiStorageBase, dummyUUID, "snapshots", dummyUUID, "export_to_s3")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -236,7 +237,7 @@ func TestClient_GetSnapshotsByLocation(t *testing.T) {
 	uri := path.Join(apiLocationBase, dummyUUID, "snapshots")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareStorageSnapshotListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -257,7 +258,7 @@ func TestClient_GetDeletedSnapshots(t *testing.T) {
 	uri := path.Join(apiDeletedBase, "snapshots")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareDeletedStorageSnapshotListHTTPGet())
 	})
 

--- a/snapshotscheduler_test.go
+++ b/snapshotscheduler_test.go
@@ -3,10 +3,11 @@ package gsclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_GetStorageSnapshotScheduleList(t *testing.T) {
@@ -15,7 +16,7 @@ func TestClient_GetStorageSnapshotScheduleList(t *testing.T) {
 	uri := path.Join(apiStorageBase, dummyUUID, "snapshot_schedules")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareStorageSnapshotScheduleListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -36,7 +37,7 @@ func TestClient_GetStorageSnapshotSchedule(t *testing.T) {
 	uri := path.Join(apiStorageBase, dummyUUID, "snapshot_schedules", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareStorageSnapshotScheduleHTTPGet("active"))
 	})
 	for _, testStorageID := range uuidCommonTestCases {
@@ -59,7 +60,7 @@ func TestClient_CreateStorageSnapshotSchedule(t *testing.T) {
 	uri := path.Join(apiStorageBase, dummyUUID, "snapshot_schedules")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -95,7 +96,7 @@ func TestClient_UpdateStorageSnapshotSchedule(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiStorageBase, dummyUUID, "snapshot_schedules", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -137,7 +138,7 @@ func TestClient_DeleteStorageSnapshotSchedule(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiStorageBase, dummyUUID, "snapshot_schedules", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {

--- a/sshkey_test.go
+++ b/sshkey_test.go
@@ -3,10 +3,11 @@ package gsclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_GetSshkeyList(t *testing.T) {
@@ -15,7 +16,7 @@ func TestClient_GetSshkeyList(t *testing.T) {
 	uri := apiSshkeyBase
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareSshkeyListHTTPGet())
 	})
 	res, err := client.GetSshkeyList(emptyCtx)
@@ -30,7 +31,7 @@ func TestClient_GetSshkey(t *testing.T) {
 	uri := path.Join(apiSshkeyBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareSshkeyHTTPGet("active"))
 	})
 	for _, test := range uuidCommonTestCases {
@@ -51,7 +52,7 @@ func TestClient_CreateSshkey(t *testing.T) {
 	uri := apiSshkeyBase
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -82,7 +83,7 @@ func TestClient_UpdateSshkey(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiSshkeyBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -118,7 +119,7 @@ func TestClient_DeleteSshkey(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiSshkeyBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -148,7 +149,7 @@ func TestClient_GetSshkeyEventList(t *testing.T) {
 	uri := path.Join(apiSshkeyBase, dummyUUID, "events")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(writer, prepareEventListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {

--- a/ssl_certificate_test.go
+++ b/ssl_certificate_test.go
@@ -16,7 +16,7 @@ func TestClient_GetSSLCertificateList(t *testing.T) {
 	uri := apiSSLCertificateBase
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareSSLCertificateListHTTPGet())
 	})
 	res, err := client.GetSSLCertificateList(emptyCtx)
@@ -31,7 +31,7 @@ func TestClient_GetSSLCertificate(t *testing.T) {
 	uri := path.Join(apiSSLCertificateBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareSSLCertificateHTTPGet("active"))
 	})
 	for _, test := range uuidCommonTestCases {
@@ -52,7 +52,7 @@ func TestClient_SSLCertificate(t *testing.T) {
 	uri := apiSSLCertificateBase
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -83,7 +83,7 @@ func TestClient_DeleteSSLCertificate(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiSSLCertificateBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {

--- a/storage_backup_schedule_test.go
+++ b/storage_backup_schedule_test.go
@@ -3,10 +3,11 @@ package gsclient
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_GetStorageBackupScheduleList(t *testing.T) {
@@ -15,7 +16,7 @@ func TestClient_GetStorageBackupScheduleList(t *testing.T) {
 	uri := path.Join(apiStorageBase, dummyUUID, "backup_schedules")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareStorageBackupScheduleListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -36,7 +37,7 @@ func TestClient_GetStorageBackupSchedule(t *testing.T) {
 	uri := path.Join(apiStorageBase, dummyUUID, "backup_schedules", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareStorageBackupScheduleHTTPGet("active"))
 	})
 	for _, testStorageID := range uuidCommonTestCases {
@@ -59,7 +60,7 @@ func TestClient_CreateStorageBackupSchedule(t *testing.T) {
 	uri := path.Join(apiStorageBase, dummyUUID, "backup_schedules")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -95,7 +96,7 @@ func TestClient_UpdateStorageBackupSchedule(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiStorageBase, dummyUUID, "backup_schedules", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
@@ -136,7 +137,7 @@ func TestClient_DeleteStorageBackupSchedule(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiStorageBase, dummyUUID, "backup_schedules", dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {

--- a/storage_backup_test.go
+++ b/storage_backup_test.go
@@ -16,7 +16,7 @@ func TestClient_GetStorageBackupList(t *testing.T) {
 	uri := path.Join(apiStorageBase, dummyUUID, "backups")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
-		writer.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareStorageBackupListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -37,7 +37,7 @@ func TestClient_DeleteStorageBackup(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiStorageBase, dummyUUID, "backups", dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -69,7 +69,7 @@ func TestClient_RollbackStorageBackup(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiStorageBase, dummyUUID, "backups", dummyUUID, "rollback")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {

--- a/storage_test.go
+++ b/storage_test.go
@@ -16,7 +16,7 @@ func TestClient_GetStorageList(t *testing.T) {
 	uri := apiStorageBase
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareStorageListHTTPGet())
 	})
 	response, err := client.GetStorageList(emptyCtx)
@@ -31,7 +31,7 @@ func TestClient_GetStorage(t *testing.T) {
 	uri := path.Join(apiStorageBase, dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareStorageHTTPGet("active"))
 	})
 	for _, test := range uuidCommonTestCases {
@@ -52,7 +52,7 @@ func TestClient_CreateStorage(t *testing.T) {
 	uri := apiStorageBase
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -91,7 +91,7 @@ func TestClient_CreateStorageFromBackup(t *testing.T) {
 	uri := path.Join(apiStorageBase, "import")
 	muxServer.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -120,7 +120,7 @@ func TestClient_UpdateStorage(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiStorageBase, dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -157,7 +157,7 @@ func TestClient_DeleteStorage(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiStorageBase, dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -187,7 +187,7 @@ func TestClient_GetStorageEventList(t *testing.T) {
 	uri := path.Join(apiStorageBase, dummyUUID, "events")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareEventListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -208,7 +208,7 @@ func TestClient_GetStoragesByLocation(t *testing.T) {
 	uri := path.Join(apiLocationBase, dummyUUID, "storages")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareStorageListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -229,7 +229,7 @@ func TestClient_GetDeletedStorages(t *testing.T) {
 	uri := path.Join(apiDeletedBase, "storages")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareDeletedStorageListHTTPGet())
 	})
 	response, err := client.GetDeletedStorages(emptyCtx)
@@ -245,7 +245,7 @@ func TestClient_CloneStorage(t *testing.T) {
 	uri := path.Join(apiStorageBase, dummyUUID, "clone")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {

--- a/template_test.go
+++ b/template_test.go
@@ -16,7 +16,7 @@ func TestClient_GetTemplateList(t *testing.T) {
 	uri := apiTemplateBase
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareTemplateListHTTPGet())
 	})
 	response, err := client.GetTemplateList(emptyCtx)
@@ -31,7 +31,7 @@ func TestClient_GetTemplate(t *testing.T) {
 	uri := path.Join(apiTemplateBase, dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareTemplateHTTPGet("active"))
 	})
 	for _, test := range uuidCommonTestCases {
@@ -62,7 +62,7 @@ func TestClient_GetTemplateByName(t *testing.T) {
 	uri := apiTemplateBase
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareTemplateListHTTPGet())
 	})
 	for _, test := range testCases {
@@ -83,7 +83,7 @@ func TestClient_CreateTemplate(t *testing.T) {
 	uri := apiTemplateBase
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -114,7 +114,7 @@ func TestClient_UpdateTemplate(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiTemplateBase, dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -150,7 +150,7 @@ func TestClient_DeleteTemplate(t *testing.T) {
 	var isFailed bool
 	uri := path.Join(apiTemplateBase, dummyUUID)
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
 			w.WriteHeader(400)
 		} else {
@@ -180,7 +180,7 @@ func TestClient_GetTemplateEventList(t *testing.T) {
 	uri := path.Join(apiTemplateBase, dummyUUID, "events")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareEventListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -201,7 +201,7 @@ func TestClient_GetTemplatesByLocation(t *testing.T) {
 	uri := path.Join(apiLocationBase, dummyUUID, "templates")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareTemplateListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
@@ -222,7 +222,7 @@ func TestClient_GetDeletedTemplates(t *testing.T) {
 	uri := path.Join(apiDeletedBase, "templates")
 	mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		w.Header().Set(requestUUIDHeaderParam, dummyRequestUUID)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(w, prepareDeletedTemplateListHTTPGet())
 	})
 	response, err := client.GetDeletedTemplates(emptyCtx)


### PR DESCRIPTION
Ref #200. Only 503 and 429 are retriable. Changes:
- Requests with 503 response code will be retried. If `Retry-After` response header is defined (x seconds), the next retry will be executed after  x seconds. If that header is not included, the next retry depends on settings of `gsclient-go` (`delayIntervalMilliSecs` and `maxNumberOfRetries`). When the retry count of a request reaches `maxNumberOfRetries`, `gsclient-go` return the last retry's error.
- Requests with 429 (rate-limit is reached) response code will also be retried when the rate-limit is reset. If the rate-limit is reached again, retry again in when the rate-limit is reset. There is no `maxNumberOfRetries` for 429 request retry.
- Update docs.
- Update unit tests.

**NOTE**: if the context is `Done()` before retrying (or during retrying). An error caused by the expired context is returned.