### PR TITLE
Add missing location's endpoints/properties

### DIFF
--- a/examples/location.go
+++ b/examples/location.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"os"
+
+	"github.com/gridscale/gsclient-go/v3"
+	log "github.com/sirupsen/logrus"
+)
+
+var emptyCtx = context.Background()
+
+func main() {
+	uuid := os.Getenv("GRIDSCALE_UUID")
+	token := os.Getenv("GRIDSCALE_TOKEN")
+	config := gsclient.DefaultConfiguration(uuid, token)
+	client := gsclient.NewClient(config)
+	log.Info("gridscale client configured")
+
+	locationList, err := client.GetLocationList(emptyCtx)
+	if err != nil {
+		log.Error("GetLocationList has failed with error", err)
+		return
+	}
+	log.WithFields(log.Fields{
+		"locations": locationList,
+	}).Info("Locations successfully retrieved")
+	log.Info("Create new location: Press 'Enter' to continue...")
+	bufio.NewReader(os.Stdin).ReadBytes('\n')
+	locationCreateRes, err := client.CreateLocation(emptyCtx, gsclient.LocationCreateRequest{
+		Name:               "Test location",
+		ParentLocationUUID: locationList[0].Properties.ObjectUUID,
+		ProductNo:          1500001,
+		CPUNodeCount:       1,
+	})
+	if err != nil {
+		log.Error("CreateLocation has failed with error", err)
+		return
+	}
+	log.WithFields(log.Fields{
+		"location uuid": locationCreateRes.ObjectUUID,
+	}).Info("A new location is successfully created")
+	defer func() {
+		err := client.DeleteLocation(emptyCtx, locationCreateRes.ObjectUUID)
+		if err != nil {
+			log.Error("DeleteLocation has failed with error", err)
+			return
+		}
+		log.WithFields(log.Fields{
+			"location uuid": locationCreateRes.ObjectUUID,
+		}).Info("Location is successfully deleted")
+	}()
+
+	log.Info("Get new location data: Press 'Enter' to continue...")
+	bufio.NewReader(os.Stdin).ReadBytes('\n')
+	newLoc, err := client.GetLocation(emptyCtx, locationCreateRes.ObjectUUID)
+	if err != nil {
+		log.Error("GetLocation has failed with error", err)
+		return
+	}
+	log.WithFields(log.Fields{
+		"new location data": newLoc,
+	}).Info("New location is successfully retrieved")
+	log.Info("Update location: Press 'Enter' to continue...")
+	bufio.NewReader(os.Stdin).ReadBytes('\n')
+	err = client.UpdateLocation(emptyCtx, newLoc.Properties.ObjectUUID, gsclient.LocationUpdateRequest{
+		Name: "test updated location",
+	})
+	if err != nil {
+		log.Error("UpdateLocation has failed with error", err)
+		return
+	}
+	updatedLoc, err := client.GetLocation(emptyCtx, newLoc.Properties.ObjectUUID)
+	if err != nil {
+		log.Error("GetLocation has failed with error", err)
+		return
+	}
+	log.WithFields(log.Fields{
+		"updated location data": updatedLoc,
+	}).Info("Updated location is successfully retrieved")
+}

--- a/location.go
+++ b/location.go
@@ -108,7 +108,7 @@ type LocationInformation struct {
 	// Website of the owner.
 	OwnerWebsite string `json:"owner_website"`
 
-	// Name of site.
+	// The name of site.
 	SiteName string `json:"site_name"`
 }
 
@@ -148,15 +148,16 @@ type LocationCreateRequest struct {
 	ProductNo int `json:"product_no"`
 }
 
-// LocationUpdateRequest represent a request for updating a location.
+// LocationUpdateRequest represents a request for updating a location.
 type LocationUpdateRequest struct {
-	// New name. Leave it if you do not want to update the name.
+	// Name is the human-readable name of the object. Name is an optional field.
 	Name string `json:"name,omitempty"`
 
-	// List of labels. Leave it if you do not want to update the labels.
+	// List of labels. Labels is an optional field.
 	Labels *[]string `json:"labels,omitempty"`
 
 	// The number of dedicated cpunodes to assigne to the private location.
+	// CPUNodeCount is an optional field.
 	CPUNodeCount *int `json:"cpunode_count,omitempty"`
 }
 

--- a/location.go
+++ b/location.go
@@ -11,6 +11,9 @@ import (
 type LocationOperator interface {
 	GetLocationList(ctx context.Context) ([]Location, error)
 	GetLocation(ctx context.Context, id string) (Location, error)
+	CreateLocation(ctx context.Context, body LocationCreateRequest) (CreateResponse, error)
+	UpdateLocation(ctx context.Context, id string, body LocationUpdateRequest) error
+	DeleteLocation(ctx context.Context, id string) error
 }
 
 // LocationList holds a list of locations.

--- a/location.go
+++ b/location.go
@@ -30,7 +30,7 @@ type LocationProperties struct {
 	// Uses IATA airport code, which works as a location identifier.
 	Iata string `json:"iata"`
 
-	// Status indicates the status of the object.
+	// Status indicates the status of the object. DEPRECATED
 	Status string `json:"status"`
 
 	// List of labels.
@@ -44,6 +44,117 @@ type LocationProperties struct {
 
 	// The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters.
 	Country string `json:"country"`
+
+	// True if the location is active.
+	Active bool `json:"active"`
+
+	// Request change.
+	ChangeRequested LocationRequestedChange `json:"change_requested"`
+
+	// The number of dedicated cpunodes to assign to the private location.
+	CPUNodeCount int `json:"cpunode_count"`
+
+	// If this location is publicly available or a private location.
+	Public bool `json:"public"`
+
+	// The product number of a valid and available dedicated cpunode article.
+	ProductNo int `json:"product_no"`
+
+	// More detail about the location.
+	LocationInformation LocationInformation `json:"location_information"`
+
+	// Feature information of the location.
+	Features LocationFeatures `json:"features"`
+}
+
+// LocationRequestedChange represents a location's requested change.
+type LocationRequestedChange struct {
+	// The requested number of dedicated cpunodes.
+	CPUNodeCount int `json:"cpunode_count"`
+
+	// The product number of a valid and available dedicated cpunode article.
+	ProductNo int `json:"product_no"`
+
+	// The location_uuid of an existing public location in which to create the private location.
+	ParentLocationUUID string `json:"parent_location_uuid"`
+}
+
+// LocationInformation represents a location's detail information.
+type LocationInformation struct {
+	// List of certifications.
+	CertificationList string `json:"certification_list"`
+
+	// City of the locations.
+	City string `json:"city"`
+
+	// Data protection agreement.
+	DataProtectionAgreement string `json:"data_protection_agreement"`
+
+	// Geo Location.
+	GeoLocation string `json:"geo_location"`
+
+	// Green energy.
+	GreenEnergy string `json:"green_energy"`
+
+	// List of operator certificate.
+	OperatorCertificationList string `json:"operator_certification_list"`
+
+	// Owner of the location.
+	Owner string `json:"owner"`
+
+	// Website of the owner.
+	OwnerWebsite string `json:"owner_website"`
+
+	// Name of site.
+	SiteName string `json:"site_name"`
+}
+
+// LocationFeatures represent a location's list of features.
+type LocationFeatures struct {
+	// List of available hardware profiles.
+	HardwareProfiles string `json:"hardware_profiles"`
+
+	// TRUE if the location has rocket storage feature.
+	HasRocketStorage string `json:"has_rocket_storage"`
+
+	// TRUE if the location has permission to provision server.
+	HasServerProvisioning string `json:"has_server_provisioning"`
+
+	// Region of object storage.
+	ObjectStorageRegion string `json:"object_storage_region"`
+
+	// Backup location UUID.
+	BackupCenterLocationUUID string `json:"backup_center_location_uuid"`
+}
+
+// LocationCreateRequest represent a payload of a request for creating a new location.
+type LocationCreateRequest struct {
+	// The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
+	Name string `json:"name"`
+
+	// List of labels.
+	Labels []string `json:"labels,omitempty"`
+
+	// The location_uuid of an existing public location in which to create the private location.
+	ParentLocationUUID string `json:"parent_location_uuid"`
+
+	// The number of dedicated cpunodes to assigne to the private location.
+	CPUNodeCount int `json:"cpunode_count"`
+
+	// The product number of a valid and available dedicated cpunode article.
+	ProductNo int `json:"product_no"`
+}
+
+// LocationUpdateRequest represent a request for updating a location.
+type LocationUpdateRequest struct {
+	// New name. Leave it if you do not want to update the name.
+	Name string `json:"name,omitempty"`
+
+	// List of labels. Leave it if you do not want to update the labels.
+	Labels *[]string `json:"labels,omitempty"`
+
+	// The number of dedicated cpunodes to assigne to the private location.
+	CPUNodeCount *int `json:"cpunode_count,omitempty"`
 }
 
 // GetLocationList gets a list of available locations.
@@ -79,4 +190,47 @@ func (c *Client) GetLocation(ctx context.Context, id string) (Location, error) {
 	var location Location
 	err := r.execute(ctx, *c, &location)
 	return location, err
+}
+
+// CreateLocation creates a new location.
+//
+// See: https://gridscale.io/en//api-documentation/index.html#operation/createLocation
+func (c *Client) CreateLocation(ctx context.Context, body LocationCreateRequest) (CreateResponse, error) {
+	r := gsRequest{
+		uri:    apiLocationBase,
+		method: http.MethodPost,
+		body:   body,
+	}
+	var response CreateResponse
+	err := r.execute(ctx, *c, &response)
+	return response, err
+}
+
+// UpdateLocation updates a specific location based on given id.
+//
+// See: https://gridscale.io/en//api-documentation/index.html#operation/updateLocation
+func (c *Client) UpdateLocation(ctx context.Context, id string, body LocationUpdateRequest) error {
+	if !isValidUUID(id) {
+		return errors.New("'id' is invalid")
+	}
+	r := gsRequest{
+		uri:    path.Join(apiLocationBase, id),
+		method: http.MethodPatch,
+		body:   body,
+	}
+	return r.execute(ctx, *c, nil)
+}
+
+// DeleteLocation removes a single Location.
+//
+// See: https://gridscale.io/en//api-documentation/index.html#operation/deleteLocation
+func (c *Client) DeleteLocation(ctx context.Context, id string) error {
+	if !isValidUUID(id) {
+		return errors.New("'id' is invalid")
+	}
+	r := gsRequest{
+		uri:    path.Join(apiLocationBase, id),
+		method: http.MethodDelete,
+	}
+	return r.execute(ctx, *c, nil)
 }

--- a/location_test.go
+++ b/location_test.go
@@ -45,6 +45,104 @@ func TestClient_GetLocation(t *testing.T) {
 	}
 }
 
+func TestClient_CreateLocation(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	var isFailed bool
+	uri := apiLocationBase
+	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, http.MethodPost, request.Method)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		if isFailed {
+			writer.WriteHeader(400)
+		} else {
+			fmt.Fprintf(writer, prepareLocationCreateResponse())
+		}
+	})
+	for _, test := range commonSuccessFailTestCases {
+		isFailed = test.isFailed
+		response, err := client.CreateLocation(
+			emptyCtx,
+			LocationCreateRequest{
+				Name:               "test",
+				ParentLocationUUID: dummyUUID,
+				CPUNodeCount:       10,
+				ProductNo:          99,
+			})
+		if isFailed {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err, "CreateLocation returned an error %v", err)
+			assert.Equal(t, fmt.Sprintf("%v", getMockLocationCreateResponse()), fmt.Sprintf("%s", response))
+		}
+	}
+}
+
+func TestClient_UpdateLocation(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	var isFailed bool
+	uri := path.Join(apiLocationBase, dummyUUID)
+	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		if isFailed {
+			writer.WriteHeader(400)
+		} else {
+			if request.Method == http.MethodPatch {
+				fmt.Fprintf(writer, "")
+			} else if request.Method == http.MethodGet {
+				fmt.Fprint(writer, prepareLocationHTTPGet())
+			}
+		}
+	})
+	for _, serverTest := range commonSuccessFailTestCases {
+		isFailed = serverTest.isFailed
+		for _, test := range uuidCommonTestCases {
+			err := client.UpdateLocation(
+				emptyCtx,
+				test.testUUID,
+				LocationUpdateRequest{
+					Name: "test",
+				})
+			if test.isFailed || isFailed {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err, "UpdateLocation returned an error %v", err)
+			}
+		}
+	}
+}
+
+func TestClient_DeleteLocation(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	var isFailed bool
+	uri := path.Join(apiLocationBase, dummyUUID)
+	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		if isFailed {
+			writer.WriteHeader(400)
+		} else {
+			if request.Method == http.MethodDelete {
+				fmt.Fprintf(writer, "")
+			} else if request.Method == http.MethodGet {
+				writer.WriteHeader(404)
+			}
+		}
+	})
+	for _, serverTest := range commonSuccessFailTestCases {
+		isFailed = serverTest.isFailed
+		for _, test := range uuidCommonTestCases {
+			err := client.DeleteLocation(emptyCtx, test.testUUID)
+			if test.isFailed || isFailed {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err, "DeleteLocation returned an error %v", err)
+			}
+		}
+	}
+}
+
 func getMockLocation() Location {
 	mock := Location{Properties: LocationProperties{
 		Iata:       "fra",
@@ -67,4 +165,17 @@ func prepareLocationListHTTPGet() string {
 	location := getMockLocation()
 	res, _ := json.Marshal(location.Properties)
 	return fmt.Sprintf(`{"locations": {"%s": %s}}`, dummyUUID, string(res))
+}
+
+func getMockLocationCreateResponse() CreateResponse {
+	mock := CreateResponse{
+		RequestUUID: dummyRequestUUID,
+		ObjectUUID:  dummyUUID,
+	}
+	return mock
+}
+
+func prepareLocationCreateResponse() string {
+	res, _ := json.Marshal(getMockLocationCreateResponse())
+	return string(res)
 }


### PR DESCRIPTION
Ref #208. Changes:
- Add missing location properties.
- Add missing location endpoints (Create/Update/Delete).
- Add location example.
- Deprecated `Status` in location's properties.