### PR TITLE
Add usage query (project/contract level)

### DIFF
--- a/client.go
+++ b/client.go
@@ -28,6 +28,8 @@ const (
 	apiLabelBase                  = "/objects/labels"
 	apiDeletedBase                = "/objects/deleted"
 	apiSSLCertificateBase         = "/objects/certificates"
+	apiProjectLevelUsage          = "/projects/usage"
+	apiContractLevelUsage         = "/contracts/usage"
 )
 
 // Client struct of a gridscale golang client.

--- a/request.go
+++ b/request.go
@@ -171,10 +171,12 @@ func (r *gsRequest) prepareHTTPRequest(ctx context.Context, cfg *Config) (*http.
 	}
 
 	// Set query parameters if there are any of them.
+	query := request.URL.Query()
 	for k, v := range r.queryParameters {
-		request.URL.Query().Add(k, v)
+		query.Add(k, v)
 	}
-
+	request.URL.RawQuery = query.Encode()
+	logger.Debugf("Finished Preparing %v request sent to URL: %v://%v%v", request.Method, request.URL.Scheme, request.URL.Host, request.URL.RequestURI())
 	return request, nil
 }
 

--- a/request.go
+++ b/request.go
@@ -22,6 +22,7 @@ type gsRequest struct {
 	uri                 string
 	method              string
 	body                interface{}
+	queryParameters     map[string]string
 	skipCheckingRequest bool
 }
 
@@ -167,6 +168,11 @@ func (r *gsRequest) prepareHTTPRequest(ctx context.Context, cfg *Config) (*http.
 	// override the headers' values if they are already set.
 	for k, v := range cfg.httpHeaders {
 		request.Header.Set(k, v)
+	}
+
+	// Set query parameters if there are any of them.
+	for k, v := range r.queryParameters {
+		request.URL.Query().Add(k, v)
 	}
 
 	return request, nil

--- a/types.go
+++ b/types.go
@@ -30,3 +30,8 @@ func (t *GSTime) UnmarshalJSON(b []byte) error {
 func (t GSTime) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.Time.Format(gsTimeLayout))
 }
+
+// String returns string representation of GSTime.
+func (t GSTime) String() string {
+	return t.Time.Format(gsTimeLayout)
+}

--- a/usage.go
+++ b/usage.go
@@ -8,6 +8,21 @@ import (
 	"strconv"
 )
 
+// UsageOperator provides an interface for operations on usage.
+type UsageOperator interface {
+	GetGeneralUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted bool, intervalVariable string) (GeneralUsage, error)
+	GetServersUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted bool, intervalVariable string) (ServersUsage, error)
+	GetDistributedStoragesUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted bool, intervalVariable string) (DistributedStoragesUsage, error)
+	GetRocketStoragesUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted bool, intervalVariable string) (RocketStoragesUsage, error)
+	GetStorageBackupsUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted bool, intervalVariable string) (StorageBackupsUsage, error)
+	etSnapshotsUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted bool, intervalVariable string) (SnapshotsUsage, error)
+	GetTemplatesUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted bool, intervalVariable string) (TemplatesUsage, error)
+	GetISOImagesUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted bool, intervalVariable string) (ISOImagesUsage, error)
+	GetIPsUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted bool, intervalVariable string) (IPsUsage, error)
+	GetLoadBalancersUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted bool, intervalVariable string) (LoadBalancersUsage, error)
+	GetPaaSServicesUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted bool, intervalVariable string) (PaaSServicesUsage, error)
+}
+
 // Usage represents usage of a product.
 type Usage struct {
 	// Number of a product.

--- a/usage.go
+++ b/usage.go
@@ -1,0 +1,904 @@
+package gsclient
+
+import (
+	"context"
+	"net/http"
+	"path"
+	"strconv"
+)
+
+// Usage represents usage of a product.
+type Usage struct {
+	// Number of a product.
+	ProductNumber int `json:"product_number"`
+
+	// Total usage of a product.
+	Value int `json:"value"`
+}
+
+// UsagePerInterval represents usage of active product within a specific interval.
+type UsagePerInterval struct {
+	// Start accumulation period.
+	IntervalStart GSTime `json:"interval_start"`
+
+	// interval_end
+	IntervalEnd GSTime `json:"interval_end"`
+
+	// Accumulation of product's usage in given period
+	AccumulatedUsage []Usage `json:"accumulated_usage"`
+}
+
+// ResourceUsageInfo represents usage of a specific resource (e.g. server, storage, etc.).
+type ResourceUsageInfo struct {
+	CurrentUsagePerMinute []Usage            `json:"current_usage_per_minute"`
+	UsagePerInterval      []UsagePerInterval `json:"usage_per_interval"`
+}
+
+// GeneralUsage represents general usage.
+type GeneralUsage struct {
+	Servers             ResourceUsageInfo `json:"servers"`
+	RocketStorages      ResourceUsageInfo `json:"rocket_storages"`
+	DistributedStorages ResourceUsageInfo `json:"distributed_storages"`
+	StorageBackups      ResourceUsageInfo `json:"storage_backups"`
+	Snapshots           ResourceUsageInfo `json:"snapshots"`
+	Templates           ResourceUsageInfo `json:"templates"`
+	IsoImages           ResourceUsageInfo `json:"iso_images"`
+	IPAddresses         ResourceUsageInfo `json:"ip_addresses"`
+	LoadBalancers       ResourceUsageInfo `json:"load_balancers"`
+	PaaSServices        ResourceUsageInfo `json:"paas_services"`
+}
+
+// ServersUsage represents usage of servers.
+type ServersUsage struct {
+	// The UUID of an object is always unique, and refers to a specific object.
+	ObjectUUID string `json:"object_uuid"`
+
+	// The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
+	Name string `json:"name"`
+
+	// Indicates the amount of memory in GB.
+	Memory int `json:"memory"`
+
+	// Number of server cores.
+	Cores int `json:"cores"`
+
+	// The power status of the server.
+	Power bool `json:"power"`
+
+	// List of labels.
+	Labels []string `json:"labels"`
+
+	// True if the object is deleted.
+	Deleted bool `json:"deleted"`
+
+	// Status indicates the status of the object. it could be in-provisioning or active.
+	Status string `json:"status"`
+
+	// Current usage of active product.
+	CurrentUsagePerMinute []Usage `json:"current_usage_per_minute"`
+
+	// Usage of active product within a specific interval.
+	UsagePerInterval []UsagePerInterval `json:"usage_per_interval"`
+}
+
+// DistributedStoragesUsage represents usage of distributed storages.
+type DistributedStoragesUsage struct {
+	// The UUID of an object is always unique, and refers to a specific object.
+	ObjectUUID string `json:"object_uuid"`
+
+	// The UUID of the Storage used to create this Snapshot.
+	ParentUUID string `json:"parent_uuid"`
+
+	// The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
+	Name string `json:"name"`
+
+	// List of labels.
+	Labels []string `json:"labels"`
+
+	// True if the object is deleted.
+	Deleted bool `json:"deleted"`
+
+	// Status indicates the status of the object. it could be in-provisioning or active.
+	Status string `json:"status"`
+
+	// Storage type.
+	// (one of storage, storage_high, storage_insane).
+	StorageType string `json:"storage_type"`
+
+	// Indicates the UUID of the last used template on this storage.
+	LastUsedTemplate string `json:"last_used_template"`
+
+	// The capacity of a storage/ISO image/template/snapshot in GB.
+	Capacity int `json:"capacity"`
+
+	// Current usage of active product.
+	CurrentUsagePerMinute []Usage `json:"current_usage_per_minute"`
+
+	// Usage of active product within a specific interval.
+	UsagePerInterval []UsagePerInterval `json:"usage_per_interval"`
+}
+
+// RocketStoragesUsage represents usage of rocket storages.
+type RocketStoragesUsage struct {
+	DistributedStoragesUsage
+}
+
+// StorageBackupsUsage represents usage of storage backups.
+type StorageBackupsUsage struct {
+	// The UUID of a backup is always unique, and refers to a specific object.
+	ObjectUUID string `json:"object_uuid"`
+
+	// The name of the backup equals schedule name plus backup UUID.
+	Name string `json:"name"`
+
+	// Defines the date and time the object was initially created.
+	CreateTime GSTime `json:"create_time"`
+
+	// Defines the date and time of the last object change.
+	ChangeTime GSTime `json:"change_time"`
+
+	// The size of a backup in GB.
+	Capacity int `json:"capacity"`
+
+	// Current usage of active product.
+	CurrentUsagePerMinute []Usage `json:"current_usage_per_minute"`
+
+	// Usage of active product within a specific interval.
+	UsagePerInterval []UsagePerInterval `json:"usage_per_interval"`
+}
+
+// SnapshotsUsage represents usage of snapshots.
+type SnapshotsUsage struct {
+	// The UUID of an object is always unique, and refers to a specific object.
+	ObjectUUID string `json:"object_uuid"`
+
+	// The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
+	Name string `json:"name"`
+
+	// Uuid of the storage used to create this snapshot.
+	ParentUUID string `json:"parent_uuid"`
+
+	// Name of the storage used to create this snapshot.
+	ParentName string `json:"parent_name"`
+
+	// Uuid of the project used to create this snapshot.
+	ProjectUUID string `json:"project_uuid"`
+
+	// List of labels.
+	Labels []string `json:"labels"`
+
+	// Status indicates the status of the object.
+	Status string `json:"status"`
+
+	// Defines the date and time the object was initially created.
+	CreateTime GSTime `json:"create_time"`
+
+	// Defines the date and time of the last object change.
+	ChangeTime GSTime `json:"change_time"`
+
+	// The capacity of a storage/ISO image/template/snapshot in GB.
+	Capacity int `json:"capacity"`
+
+	// True if the object is deleted.
+	Deleted bool `json:"deleted"`
+
+	// Current usage of active product.
+	CurrentUsagePerMinute []Usage `json:"current_usage_per_minute"`
+
+	// Usage of active product within a specific interval.
+	UsagePerInterval []UsagePerInterval `json:"usage_per_interval"`
+}
+
+// TemplatesUsage represents usage of templates.
+type TemplatesUsage struct {
+	// The UUID of an object is always unique, and refers to a specific object.
+	ObjectUUID string `json:"object_uuid"`
+
+	// The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
+	Name string `json:"name"`
+
+	// Status indicates the status of the object.
+	Status string `json:"status"`
+
+	// Status indicates the status of the object.
+	Ostype string `json:"ostype"`
+
+	// A version string for this template.
+	Version string `json:"version"`
+
+	// Defines the date and time the object was initially created.
+	CreateTime GSTime `json:"create_time"`
+
+	// Defines the date and time of the last change.
+	ChangeTime GSTime `json:"change_time"`
+
+	// Whether the object is private, the value will be true. Otherwise the value will be false.
+	Private bool `json:"private"`
+
+	// If a template has been used that requires a license key (e.g. Windows Servers)
+	// this shows the product_no of the license (see the /prices endpoint for more details).
+	LicenseProductNo int `json:"license_product_no"`
+
+	// The capacity of a storage/ISO image/template/snapshot in GiB.
+	Capacity int `json:"capacity"`
+
+	// The OS distribution of this template.
+	Distro string `json:"distro"`
+
+	// Description of the template.
+	Description string `json:"description"`
+
+	// List of labels.
+	Labels []string `json:"labels"`
+
+	// Uuid of the project used to create this template.
+	ProjectUUID string `json:"project_uuid"`
+
+	// True if the object is deleted.
+	Deleted bool `json:"deleted"`
+
+	// Current usage of active product.
+	CurrentUsagePerMinute []Usage `json:"current_usage_per_minute"`
+
+	// Usage of active product within a specific interval.
+	UsagePerInterval []UsagePerInterval `json:"usage_per_interval"`
+}
+
+// ISOImagesUsage represents usage of ISO images.
+type ISOImagesUsage struct {
+	// The UUID of an object is always unique, and refers to a specific object.
+	ObjectUUID string `json:"object_uuid"`
+
+	// The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
+	Name string `json:"name"`
+
+	// Description of the ISO image release.
+	Description string `json:"description"`
+
+	// Contains the source URL of the ISO image that it was originally fetched from.
+	SourceURL string `json:"source_url"`
+
+	// List of labels.
+	Labels []string `json:"labels"`
+
+	// Status indicates the status of the object.
+	Status string `json:"status"`
+
+	// Defines the date and time the object was initially created.
+	CreateTime GSTime `json:"create_time"`
+
+	// Defines the date and time of the last object change.
+	ChangeTime GSTime `json:"change_time"`
+
+	// Upstream version of the ISO image release.
+	Version string `json:"version"`
+
+	// Whether the ISO image is private or not.
+	Private bool `json:"private"`
+
+	// The capacity of an ISO image in GB.
+	Capacity int `json:"capacity"`
+
+	// Uuid of the project used to create this ISO image.
+	ProjectUUID string `json:"project_uuid"`
+
+	// True if the object is deleted.
+	Deleted bool `json:"deleted"`
+
+	// Current usage of active product.
+	CurrentUsagePerMinute []Usage `json:"current_usage_per_minute"`
+
+	// Usage of active product within a specific interval.
+	UsagePerInterval []UsagePerInterval `json:"usage_per_interval"`
+}
+
+// IPsUsage represents usage of IP addresses.
+type IPsUsage struct {
+	// The UUID of an object is always unique, and refers to a specific object.
+	ObjectUUID string `json:"object_uuid"`
+
+	// The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
+	Name string `json:"name"`
+
+	// Defines the IP Address (v4 or v6).
+	IP string `json:"ip"`
+
+	// Enum:4 6. The IP Address family (v4 or v6).
+	Family int `json:"family"`
+
+	// Defines the date and time the object was initially created.
+	CreateTime GSTime `json:"create_time"`
+
+	// Defines the date and time of the last object change.
+	ChangeTime GSTime `json:"change_time"`
+
+	// Status indicates the status of the object.
+	Status string `json:"status"`
+
+	// The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters.
+	LocationCountry string `json:"location_country"`
+
+	// The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters.
+	LocationName string `json:"location_name"`
+
+	// Uses IATA airport code, which works as a location identifier.
+	LocationIata string `json:"location_iata"`
+
+	// Helps to identify which data center an object belongs to.
+	LocationUUID string `json:"location_uuid"`
+
+	// The IP prefix.
+	Prefix string `json:"prefix"`
+
+	// Defines if the object is administratively blocked. If true, it can not be deleted by the user.
+	DeleteBlock bool `json:"delete_block"`
+
+	// Sets failover mode for this IP. If true, then this IP is no longer available for DHCP and can no longer be related to any server.
+	Failover bool `json:"failover"`
+
+	// List of labels.
+	Labels []string `json:"labels"`
+
+	// Defines the reverse DNS entry for the IP Address (PTR Resource Record).
+	ReverseDNS string `json:"reverse_dns"`
+
+	// Uuid of the partner used to create this IP address.
+	PartnerUUID string `json:"partner_uuid"`
+
+	// Uuid of the project used to create this IP address.
+	ProjectUUID string `json:"project_uuid"`
+
+	// True if the object is deleted.
+	Deleted bool `json:"deleted"`
+
+	// Current usage of active product.
+	CurrentUsagePerMinute []Usage `json:"current_usage_per_minute"`
+
+	// Usage of active product within a specific interval.
+	UsagePerInterval []UsagePerInterval `json:"usage_per_interval"`
+}
+
+// LoadBalancersUsage represents usage of storage backups.
+type LoadBalancersUsage struct {
+	// The UUID of an object is always unique, and refers to a specific object.
+	ObjectUUID string `json:"object_uuid"`
+
+	// The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
+	Name string `json:"name"`
+
+	// Forwarding rules of a load balancer.
+	ForwardingRules []ForwardingRule `json:"forwarding_rules"`
+
+	// The servers that this Load balancer can communicate with.
+	BackendServers []BackendServer `json:"backend_servers"`
+
+	// Defines the date and time the object was initially created.
+	CreateTime GSTime `json:"create_time"`
+
+	// Defines the date and time of the last object change.
+	ChangeTime GSTime `json:"change_time"`
+
+	// Status indicates the status of the object.
+	Status string `json:"status"`
+
+	// Whether the Load balancer is forced to redirect requests from HTTP to HTTPS.
+	RedirectHTTPToHTTPS bool `json:"redirect_http_to_https"`
+
+	// The algorithm used to process requests. Accepted values: roundrobin / leastconn.
+	Algorithm string `json:"algorithm"`
+
+	// The UUID of the IPv6 address the Load balancer will listen to for incoming requests.
+	ListenIPv6UUID string `json:"listen_ipv6_uuid"`
+
+	// The UUID of the IPv4 address the Load balancer will listen to for incoming requests.
+	ListenIPv4UUID string `json:"listen_ipv4_uuid"`
+
+	// Current usage of active product.
+	CurrentUsagePerMinute []Usage `json:"current_usage_per_minute"`
+
+	// Usage of active product within a specific interval.
+	UsagePerInterval []UsagePerInterval `json:"usage_per_interval"`
+}
+
+// PaaSUsage represents usage of PaaS services.
+type PaaSUsage struct {
+	// The UUID of an object is always unique, and refers to a specific object.
+	ObjectUUID string `json:"object_uuid"`
+
+	// The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
+	Name string `json:"name"`
+
+	// Status indicates the status of the object.
+	Status string `json:"status"`
+
+	// Contains the initial setup credentials for Service.
+	Credentials []Credential `json:"credentials"`
+
+	// Defines the date and time the object was initially created.
+	CreateTime GSTime `json:"create_time"`
+
+	// Defines the date and time of the last object change.
+	ChangeTime GSTime `json:"change_time"`
+
+	// The template used to create the service, you can find an available list at the /service_templates endpoint.
+	ServiceTemplateUUID string `json:"service_template_uuid"`
+
+	// Contains the service parameters for the service.
+	Parameters map[string]interface{} `json:"parameters"`
+
+	// A list of service resource limits.
+	ResourceLimits []ResourceLimit `json:"resource_limits"`
+
+	// Uuid of the project used to create this PaaS.
+	ProjectUUID string `json:"project_uuid"`
+
+	// True if the object is deleted.
+	Deleted bool `json:"deleted"`
+
+	// Current usage of active product.
+	CurrentUsagePerMinute []Usage `json:"current_usage_per_minute"`
+
+	// Usage of active product within a specific interval.
+	UsagePerInterval []UsagePerInterval `json:"usage_per_interval"`
+}
+
+// IntervalVariable represents interval variable when querying usage.
+// IntervalVariable is used to get usage of resources within time intervals.
+type IntervalVariable string
+
+// All allowed interval variable's values
+const (
+	HourIntervalVariable  IntervalVariable = "H"
+	DayIntervalVariable   IntervalVariable = "D"
+	WeekIntervalVariable  IntervalVariable = "W"
+	MonthIntervalVariable IntervalVariable = "M"
+)
+
+type usageQueryLevel int
+
+const (
+	// ProjectLevelUsage is used to query resources' usage in project level.
+	ProjectLevelUsage usageQueryLevel = iota
+
+	// ContractLevelUsage is used to query resources' usage in contract level.
+	ContractLevelUsage = iota
+)
+
+// GetGeneralUsage returns general usage of all resources in project/contract level.
+// Args:
+//		- queryLevel (Required): resources' usage query level. Either ProjectLevelUsage or ContractLevelUsage.
+// 		- fromTime (Required): Starting time when the usage should be calculated.
+//		- toTime (Optional, can be nil): End time when the usage should be calculated.
+//		- withoutDeleted (Optional, can be nil): To calculate the usage with or without deleted resources.
+//		- intervalVariable (Optional, can be nil): HourIntervalVariable, DayIntervalVariable, WeekIntervalVariable, MonthIntervalVariable.
+//
+// See: https://gridscale.io/en/api-documentation/index.html#operation/ProjectLevelUsageGet
+func (c *Client) GetGeneralUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted *bool, intervalVariable *IntervalVariable) (GeneralUsage, error) {
+	queryParam := map[string]string{
+		"from_time": fromTime.String(),
+	}
+	if toTime != nil {
+		queryParam["to_time"] = toTime.String()
+	}
+	if withoutDeleted != nil {
+		queryParam["without_deleted"] = strconv.FormatBool(*withoutDeleted)
+	}
+	if intervalVariable != nil {
+		queryParam["interval_variable"] = string(*intervalVariable)
+	}
+	var uri string
+	switch queryLevel {
+	case ProjectLevelUsage:
+		uri = apiProjectLevelUsage
+	case ContractLevelUsage:
+		uri = apiContractLevelUsage
+	}
+	r := gsRequest{
+		uri:                 uri,
+		method:              http.MethodGet,
+		skipCheckingRequest: true,
+		queryParameters:     queryParam,
+	}
+	var response GeneralUsage
+	err := r.execute(ctx, *c, &response)
+	return response, err
+}
+
+// GetServersUsage returns usage of all servers in project/contract level.
+// Args:
+//		- queryLevel (Required): resources' usage query level. Either ProjectLevelUsage or ContractLevelUsage.
+// 		- fromTime (Required): Starting time when the usage should be calculated.
+//		- toTime (Optional, can be nil): End time when the usage should be calculated.
+//		- withoutDeleted (Optional, can be nil): To calculate the usage with or without deleted resources.
+//		- intervalVariable (Optional, can be nil): HourIntervalVariable, DayIntervalVariable, WeekIntervalVariable, MonthIntervalVariable.
+//
+// See: https://gridscale.io/en/api-documentation/index.html#operation/ProjectLevelServerUsageGet
+func (c *Client) GetServersUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted *bool, intervalVariable *IntervalVariable) (ServersUsage, error) {
+	queryParam := map[string]string{
+		"from_time": fromTime.String(),
+	}
+	if toTime != nil {
+		queryParam["to_time"] = toTime.String()
+	}
+	if withoutDeleted != nil {
+		queryParam["without_deleted"] = strconv.FormatBool(*withoutDeleted)
+	}
+	if intervalVariable != nil {
+		queryParam["interval_variable"] = string(*intervalVariable)
+	}
+	var uri string
+	switch queryLevel {
+	case ProjectLevelUsage:
+		uri = apiProjectLevelUsage
+	case ContractLevelUsage:
+		uri = apiContractLevelUsage
+	}
+	r := gsRequest{
+		uri:                 path.Join(uri, "servers"),
+		method:              http.MethodGet,
+		skipCheckingRequest: true,
+		queryParameters:     queryParam,
+	}
+	var response ServersUsage
+	err := r.execute(ctx, *c, &response)
+	return response, err
+}
+
+// GetDistributedStoragesUsage returns usage of all distributed storages in project/contract level.
+// Args:
+//		- queryLevel (Required): resources' usage query level. Either ProjectLevelUsage or ContractLevelUsage.
+// 		- fromTime (Required): Starting time when the usage should be calculated.
+//		- toTime (Optional, can be nil): End time when the usage should be calculated.
+//		- withoutDeleted (Optional, can be nil): To calculate the usage with or without deleted resources.
+//		- intervalVariable (Optional, can be nil): HourIntervalVariable, DayIntervalVariable, WeekIntervalVariable, MonthIntervalVariable.
+//
+// See: https://gridscale.io/en/api-documentation/index.html#operation/ProjectLevelDistributedStorageUsageGet
+func (c *Client) GetDistributedStoragesUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted *bool, intervalVariable *IntervalVariable) (DistributedStoragesUsage, error) {
+	queryParam := map[string]string{
+		"from_time": fromTime.String(),
+	}
+	if toTime != nil {
+		queryParam["to_time"] = toTime.String()
+	}
+	if withoutDeleted != nil {
+		queryParam["without_deleted"] = strconv.FormatBool(*withoutDeleted)
+	}
+	if intervalVariable != nil {
+		queryParam["interval_variable"] = string(*intervalVariable)
+	}
+	var uri string
+	switch queryLevel {
+	case ProjectLevelUsage:
+		uri = apiProjectLevelUsage
+	case ContractLevelUsage:
+		uri = apiContractLevelUsage
+	}
+	r := gsRequest{
+		uri:                 path.Join(uri, "distributed_storages"),
+		method:              http.MethodGet,
+		skipCheckingRequest: true,
+		queryParameters:     queryParam,
+	}
+	var response DistributedStoragesUsage
+	err := r.execute(ctx, *c, &response)
+	return response, err
+}
+
+// GetRocketStoragesUsage returns usage of all servers in project/contract level.
+// Args:
+// 		- fromTime (Required): Starting time when the usage should be calculated.
+//		- toTime (Optional, can be nil): End time when the usage should be calculated.
+//		- withoutDeleted (Optional, can be nil): To calculate the usage with or without deleted resources.
+//		- intervalVariable (Optional, can be nil): HourIntervalVariable, DayIntervalVariable, WeekIntervalVariable, MonthIntervalVariable.
+//
+// See: https://gridscale.io/en/api-documentation/index.html#operation/ProjectLevelRocketStorageUsageGet
+func (c *Client) GetRocketStoragesUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted *bool, intervalVariable *IntervalVariable) (RocketStoragesUsage, error) {
+	queryParam := map[string]string{
+		"from_time": fromTime.String(),
+	}
+	if toTime != nil {
+		queryParam["to_time"] = toTime.String()
+	}
+	if withoutDeleted != nil {
+		queryParam["without_deleted"] = strconv.FormatBool(*withoutDeleted)
+	}
+	if intervalVariable != nil {
+		queryParam["interval_variable"] = string(*intervalVariable)
+	}
+	var uri string
+	switch queryLevel {
+	case ProjectLevelUsage:
+		uri = apiProjectLevelUsage
+	case ContractLevelUsage:
+		uri = apiContractLevelUsage
+	}
+	r := gsRequest{
+		uri:                 path.Join(uri, "rocket_storages"),
+		method:              http.MethodGet,
+		skipCheckingRequest: true,
+		queryParameters:     queryParam,
+	}
+	var response RocketStoragesUsage
+	err := r.execute(ctx, *c, &response)
+	return response, err
+}
+
+// GetStorageBackupsUsage returns usage of all storage backups in project/contract level.
+// Args:
+//		- queryLevel (Required): resources' usage query level. Either ProjectLevelUsage or ContractLevelUsage.
+// 		- fromTime (Required): Starting time when the usage should be calculated.
+//		- toTime (Optional, can be nil): End time when the usage should be calculated.
+//		- withoutDeleted (Optional, can be nil): To calculate the usage with or without deleted resources.
+//		- intervalVariable (Optional, can be nil): HourIntervalVariable, DayIntervalVariable, WeekIntervalVariable, MonthIntervalVariable.
+//
+// See: https://gridscale.io/en/api-documentation/index.html#operation/ProjectLevelStorageBackupUsageGet
+func (c *Client) GetStorageBackupsUsage(ctx context.Context, fromTime GSTime, queryLevel usageQueryLevel, toTime *GSTime, withoutDeleted *bool, intervalVariable *IntervalVariable) (StorageBackupsUsage, error) {
+	queryParam := map[string]string{
+		"from_time": fromTime.String(),
+	}
+	if toTime != nil {
+		queryParam["to_time"] = toTime.String()
+	}
+	if withoutDeleted != nil {
+		queryParam["without_deleted"] = strconv.FormatBool(*withoutDeleted)
+	}
+	if intervalVariable != nil {
+		queryParam["interval_variable"] = string(*intervalVariable)
+	}
+	var uri string
+	switch queryLevel {
+	case ProjectLevelUsage:
+		uri = apiProjectLevelUsage
+	case ContractLevelUsage:
+		uri = apiContractLevelUsage
+	}
+	r := gsRequest{
+		uri:                 path.Join(uri, "rocket_storages"),
+		method:              http.MethodGet,
+		skipCheckingRequest: true,
+		queryParameters:     queryParam,
+	}
+	var response StorageBackupsUsage
+	err := r.execute(ctx, *c, &response)
+	return response, err
+}
+
+// GetSnapshotsUsage returns usage of all snapshots in project/contract level.
+// Args:
+//		- queryLevel (Required): resources' usage query level. Either ProjectLevelUsage or ContractLevelUsage.
+// 		- fromTime (Required): Starting time when the usage should be calculated.
+//		- toTime (Optional, can be nil): End time when the usage should be calculated.
+//		- withoutDeleted (Optional, can be nil): To calculate the usage with or without deleted resources.
+//		- intervalVariable (Optional, can be nil): HourIntervalVariable, DayIntervalVariable, WeekIntervalVariable, MonthIntervalVariable.
+//
+// See: https://gridscale.io/en/api-documentation/index.html#operation/ProjectLevelSnapshotUsageGet
+func (c *Client) GetSnapshotsUsage(ctx context.Context, fromTime GSTime, queryLevel usageQueryLevel, toTime *GSTime, withoutDeleted *bool, intervalVariable *IntervalVariable) (SnapshotsUsage, error) {
+	queryParam := map[string]string{
+		"from_time": fromTime.String(),
+	}
+	if toTime != nil {
+		queryParam["to_time"] = toTime.String()
+	}
+	if withoutDeleted != nil {
+		queryParam["without_deleted"] = strconv.FormatBool(*withoutDeleted)
+	}
+	if intervalVariable != nil {
+		queryParam["interval_variable"] = string(*intervalVariable)
+	}
+	var uri string
+	switch queryLevel {
+	case ProjectLevelUsage:
+		uri = apiProjectLevelUsage
+	case ContractLevelUsage:
+		uri = apiContractLevelUsage
+	}
+	r := gsRequest{
+		uri:                 path.Join(uri, "snapshots"),
+		method:              http.MethodGet,
+		skipCheckingRequest: true,
+		queryParameters:     queryParam,
+	}
+	var response SnapshotsUsage
+	err := r.execute(ctx, *c, &response)
+	return response, err
+}
+
+// GetTemplatesUsage returns usage of all templates in project/contract level.
+// Args:
+//		- queryLevel (Required): resources' usage query level. Either ProjectLevelUsage or ContractLevelUsage.
+// 		- fromTime (Required): Starting time when the usage should be calculated.
+//		- toTime (Optional, can be nil): End time when the usage should be calculated.
+//		- withoutDeleted (Optional, can be nil): To calculate the usage with or without deleted resources.
+//		- intervalVariable (Optional, can be nil): HourIntervalVariable, DayIntervalVariable, WeekIntervalVariable, MonthIntervalVariable.
+//
+// See: https://gridscale.io/en/api-documentation/index.html#operation/ProjectLevelTemplateUsageGet
+func (c *Client) GetTemplatesUsage(ctx context.Context, fromTime GSTime, queryLevel usageQueryLevel, toTime *GSTime, withoutDeleted *bool, intervalVariable *IntervalVariable) (TemplatesUsage, error) {
+	queryParam := map[string]string{
+		"from_time": fromTime.String(),
+	}
+	if toTime != nil {
+		queryParam["to_time"] = toTime.String()
+	}
+	if withoutDeleted != nil {
+		queryParam["without_deleted"] = strconv.FormatBool(*withoutDeleted)
+	}
+	if intervalVariable != nil {
+		queryParam["interval_variable"] = string(*intervalVariable)
+	}
+	var uri string
+	switch queryLevel {
+	case ProjectLevelUsage:
+		uri = apiProjectLevelUsage
+	case ContractLevelUsage:
+		uri = apiContractLevelUsage
+	}
+	r := gsRequest{
+		uri:                 path.Join(uri, "templates"),
+		method:              http.MethodGet,
+		skipCheckingRequest: true,
+		queryParameters:     queryParam,
+	}
+	var response TemplatesUsage
+	err := r.execute(ctx, *c, &response)
+	return response, err
+}
+
+// GetISOImagesUsage returns usage of all ISO images in project/contract level.
+// Args:
+//		- queryLevel (Required): resources' usage query level. Either ProjectLevelUsage or ContractLevelUsage.
+// 		- fromTime (Required): Starting time when the usage should be calculated.
+//		- toTime (Optional, can be nil): End time when the usage should be calculated.
+//		- withoutDeleted (Optional, can be nil): To calculate the usage with or without deleted resources.
+//		- intervalVariable (Optional, can be nil): HourIntervalVariable, DayIntervalVariable, WeekIntervalVariable, MonthIntervalVariable.
+//
+// See: https://gridscale.io/en/api-documentation/index.html#operation/ProjectLevelIsoimageUsageGet
+func (c *Client) GetISOImagesUsage(ctx context.Context, fromTime GSTime, queryLevel usageQueryLevel, toTime *GSTime, withoutDeleted *bool, intervalVariable *IntervalVariable) (ISOImagesUsage, error) {
+	queryParam := map[string]string{
+		"from_time": fromTime.String(),
+	}
+	if toTime != nil {
+		queryParam["to_time"] = toTime.String()
+	}
+	if withoutDeleted != nil {
+		queryParam["without_deleted"] = strconv.FormatBool(*withoutDeleted)
+	}
+	if intervalVariable != nil {
+		queryParam["interval_variable"] = string(*intervalVariable)
+	}
+	var uri string
+	switch queryLevel {
+	case ProjectLevelUsage:
+		uri = apiProjectLevelUsage
+	case ContractLevelUsage:
+		uri = apiContractLevelUsage
+	}
+	r := gsRequest{
+		uri:                 path.Join(uri, "iso_images"),
+		method:              http.MethodGet,
+		skipCheckingRequest: true,
+		queryParameters:     queryParam,
+	}
+	var response ISOImagesUsage
+	err := r.execute(ctx, *c, &response)
+	return response, err
+}
+
+// GetIPsUsage returns usage of all IP addresses' usage in project/contract level.
+// Args:
+//		- queryLevel (Required): resources' usage query level. Either ProjectLevelUsage or ContractLevelUsage.
+// 		- fromTime (Required): Starting time when the usage should be calculated.
+//		- toTime (Optional, can be nil): End time when the usage should be calculated.
+//		- withoutDeleted (Optional, can be nil): To calculate the usage with or without deleted resources.
+//		- intervalVariable (Optional, can be nil): HourIntervalVariable, DayIntervalVariable, WeekIntervalVariable, MonthIntervalVariable.
+//
+// See: https://gridscale.io/en/api-documentation/index.html#operation/ProjectLevelIpUsageGet
+func (c *Client) GetIPsUsage(ctx context.Context, fromTime GSTime, queryLevel usageQueryLevel, toTime *GSTime, withoutDeleted *bool, intervalVariable *IntervalVariable) (IPsUsage, error) {
+	queryParam := map[string]string{
+		"from_time": fromTime.String(),
+	}
+	if toTime != nil {
+		queryParam["to_time"] = toTime.String()
+	}
+	if withoutDeleted != nil {
+		queryParam["without_deleted"] = strconv.FormatBool(*withoutDeleted)
+	}
+	if intervalVariable != nil {
+		queryParam["interval_variable"] = string(*intervalVariable)
+	}
+	var uri string
+	switch queryLevel {
+	case ProjectLevelUsage:
+		uri = apiProjectLevelUsage
+	case ContractLevelUsage:
+		uri = apiContractLevelUsage
+	}
+	r := gsRequest{
+		uri:                 path.Join(uri, "ip_addresses"),
+		method:              http.MethodGet,
+		skipCheckingRequest: true,
+		queryParameters:     queryParam,
+	}
+	var response IPsUsage
+	err := r.execute(ctx, *c, &response)
+	return response, err
+}
+
+// GetLoadBalancersUsage returns usage of all Load Balancers' usage in project/contract level.
+// Args:
+//		- queryLevel (Required): resources' usage query level. Either ProjectLevelUsage or ContractLevelUsage.
+// 		- fromTime (Required): Starting time when the usage should be calculated.
+//		- toTime (Optional, can be nil): End time when the usage should be calculated.
+//		- withoutDeleted (Optional, can be nil): To calculate the usage with or without deleted resources.
+//		- intervalVariable (Optional, can be nil): HourIntervalVariable, DayIntervalVariable, WeekIntervalVariable, MonthIntervalVariable.
+//
+// See: https://gridscale.io/en/api-documentation/index.html#operation/ProjectLevelLoadbalancerUsageGet
+func (c *Client) GetLoadBalancersUsage(ctx context.Context, fromTime GSTime, queryLevel usageQueryLevel, toTime *GSTime, withoutDeleted *bool, intervalVariable *IntervalVariable) (LoadBalancersUsage, error) {
+	queryParam := map[string]string{
+		"from_time": fromTime.String(),
+	}
+	if toTime != nil {
+		queryParam["to_time"] = toTime.String()
+	}
+	if withoutDeleted != nil {
+		queryParam["without_deleted"] = strconv.FormatBool(*withoutDeleted)
+	}
+	if intervalVariable != nil {
+		queryParam["interval_variable"] = string(*intervalVariable)
+	}
+	var uri string
+	switch queryLevel {
+	case ProjectLevelUsage:
+		uri = apiProjectLevelUsage
+	case ContractLevelUsage:
+		uri = apiContractLevelUsage
+	}
+	r := gsRequest{
+		uri:                 path.Join(uri, "load_balancers"),
+		method:              http.MethodGet,
+		skipCheckingRequest: true,
+		queryParameters:     queryParam,
+	}
+	var response LoadBalancersUsage
+	err := r.execute(ctx, *c, &response)
+	return response, err
+}
+
+// GetPaaSServicesUsage returns usage of all PaaS services' usage in project/contract level.
+// Args:
+//		- queryLevel (Required): resources' usage query level. Either ProjectLevelUsage or ContractLevelUsage.
+// 		- fromTime (Required): Starting time when the usage should be calculated.
+//		- toTime (Optional, can be nil): End time when the usage should be calculated.
+//		- withoutDeleted (Optional, can be nil): To calculate the usage with or without deleted resources.
+//		- intervalVariable (Optional, can be nil): HourIntervalVariable, DayIntervalVariable, WeekIntervalVariable, MonthIntervalVariable.
+//
+// See: https://gridscale.io/en/api-documentation/index.html#operation/ProjectLevelPaasServiceUsageGet
+func (c *Client) GetPaaSServicesUsage(ctx context.Context, fromTime GSTime, queryLevel usageQueryLevel, toTime *GSTime, withoutDeleted *bool, intervalVariable *IntervalVariable) (PaaSUsage, error) {
+	queryParam := map[string]string{
+		"from_time": fromTime.String(),
+	}
+	if toTime != nil {
+		queryParam["to_time"] = toTime.String()
+	}
+	if withoutDeleted != nil {
+		queryParam["without_deleted"] = strconv.FormatBool(*withoutDeleted)
+	}
+	if intervalVariable != nil {
+		queryParam["interval_variable"] = string(*intervalVariable)
+	}
+	var uri string
+	switch queryLevel {
+	case ProjectLevelUsage:
+		uri = apiProjectLevelUsage
+	case ContractLevelUsage:
+		uri = apiContractLevelUsage
+	}
+	r := gsRequest{
+		uri:                 path.Join(uri, "paas_services"),
+		method:              http.MethodGet,
+		skipCheckingRequest: true,
+		queryParameters:     queryParam,
+	}
+	var response PaaSUsage
+	err := r.execute(ctx, *c, &response)
+	return response, err
+}

--- a/usage.go
+++ b/usage.go
@@ -37,6 +37,11 @@ type ResourceUsageInfo struct {
 
 // GeneralUsage represents general usage.
 type GeneralUsage struct {
+	ResourcesUsage GeneralUsageProperties `json:"products"`
+}
+
+// GeneralUsageProperties holds GeneralUsage's properties.
+type GeneralUsageProperties struct {
 	Servers             ResourceUsageInfo `json:"servers"`
 	RocketStorages      ResourceUsageInfo `json:"rocket_storages"`
 	DistributedStorages ResourceUsageInfo `json:"distributed_storages"`
@@ -51,6 +56,11 @@ type GeneralUsage struct {
 
 // ServersUsage represents usage of servers.
 type ServersUsage struct {
+	ResourcesUsage []ServerUsageProperties `json:"servers"`
+}
+
+// ServerUsageProperties holds properties of a server usage.
+type ServerUsageProperties struct {
 	// The UUID of an object is always unique, and refers to a specific object.
 	ObjectUUID string `json:"object_uuid"`
 
@@ -82,8 +92,18 @@ type ServersUsage struct {
 	UsagePerInterval []UsagePerInterval `json:"usage_per_interval"`
 }
 
-// StoragesUsage represents usage of distributed/rocket storages.
-type StoragesUsage struct {
+// DistributedStoragesUsage represents usage of distributed storages.
+type DistributedStoragesUsage struct {
+	ResourcesUsage []StorageUsageProperties `json:"distributed_storages"`
+}
+
+// RocketStoragesUsage represents usage of rocket storages.
+type RocketStoragesUsage struct {
+	ResourcesUsage []StorageUsageProperties `json:"rocket_storages"`
+}
+
+// StorageUsageProperties holds the properties of a distributed/rocket storage usage.
+type StorageUsageProperties struct {
 	// The UUID of an object is always unique, and refers to a specific object.
 	ObjectUUID string `json:"object_uuid"`
 
@@ -121,6 +141,11 @@ type StoragesUsage struct {
 
 // StorageBackupsUsage represents usage of storage backups.
 type StorageBackupsUsage struct {
+	ResourcesUsage []StorageBackupUsageProperties `json:"storage_backups"`
+}
+
+// StorageBackupUsageProperties holds properties of a storage bakup usage.
+type StorageBackupUsageProperties struct {
 	// The UUID of a backup is always unique, and refers to a specific object.
 	ObjectUUID string `json:"object_uuid"`
 
@@ -145,6 +170,11 @@ type StorageBackupsUsage struct {
 
 // SnapshotsUsage represents usage of snapshots.
 type SnapshotsUsage struct {
+	ResourcesUsage []SnapshotUsageProperties `json:"snapshots"`
+}
+
+// SnapshotUsageProperties holds properties of a snapshot usage.
+type SnapshotUsageProperties struct {
 	// The UUID of an object is always unique, and refers to a specific object.
 	ObjectUUID string `json:"object_uuid"`
 
@@ -187,6 +217,11 @@ type SnapshotsUsage struct {
 
 // TemplatesUsage represents usage of templates.
 type TemplatesUsage struct {
+	ResourcesUsage []TemplateUsageProperties `json:"templates"`
+}
+
+// TemplateUsageProperties holds properties of a template usage.
+type TemplateUsageProperties struct {
 	// The UUID of an object is always unique, and refers to a specific object.
 	ObjectUUID string `json:"object_uuid"`
 
@@ -242,6 +277,11 @@ type TemplatesUsage struct {
 
 // ISOImagesUsage represents usage of ISO images.
 type ISOImagesUsage struct {
+	ResourcesUsage []ISOImageUsageProperties `json:"iso_images"`
+}
+
+// ISOImageUsageProperties holds properties of an ISO Image usage.
+type ISOImageUsageProperties struct {
 	// The UUID of an object is always unique, and refers to a specific object.
 	ObjectUUID string `json:"object_uuid"`
 
@@ -290,6 +330,11 @@ type ISOImagesUsage struct {
 
 // IPsUsage represents usage of IP addresses.
 type IPsUsage struct {
+	ResourcesUsage []IPUsageProperties `json:"ip_addresses"`
+}
+
+// IPUsageProperties holds properties of an IP address usage.
+type IPUsageProperties struct {
 	// The UUID of an object is always unique, and refers to a specific object.
 	ObjectUUID string `json:"object_uuid"`
 
@@ -356,6 +401,11 @@ type IPsUsage struct {
 
 // LoadBalancersUsage represents usage of storage backups.
 type LoadBalancersUsage struct {
+	ResourcesUsage []LoadBalancerUsageProperties `json:"load_balancers"`
+}
+
+// LoadBalancerUsageProperties holds properties of a loadbalancer usage.
+type LoadBalancerUsageProperties struct {
 	// The UUID of an object is always unique, and refers to a specific object.
 	ObjectUUID string `json:"object_uuid"`
 
@@ -398,6 +448,11 @@ type LoadBalancersUsage struct {
 
 // PaaSServicesUsage represents usage of PaaS services.
 type PaaSServicesUsage struct {
+	ResourcesUsage []PaaSServiceUsageProperties `json:"paas_services"`
+}
+
+// PaaSServiceUsageProperties holds properties of a PaaS service usage.
+type PaaSServiceUsageProperties struct {
 	// The UUID of an object is always unique, and refers to a specific object.
 	ObjectUUID string `json:"object_uuid"`
 
@@ -543,7 +598,7 @@ func (c *Client) GetServersUsage(ctx context.Context, queryLevel usageQueryLevel
 //		- intervalVariable (Optional, can be empty ""): HourIntervalVariable, DayIntervalVariable, WeekIntervalVariable, MonthIntervalVariable, or "".
 //
 // See: https://gridscale.io/en/api-documentation/index.html#operation/ProjectLevelDistributedStorageUsageGet
-func (c *Client) GetDistributedStoragesUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted bool, intervalVariable string) (StoragesUsage, error) {
+func (c *Client) GetDistributedStoragesUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted bool, intervalVariable string) (DistributedStoragesUsage, error) {
 	queryParam := map[string]string{
 		"from_time":         fromTime.String(),
 		"without_deleted":   strconv.FormatBool(withoutDeleted),
@@ -559,7 +614,7 @@ func (c *Client) GetDistributedStoragesUsage(ctx context.Context, queryLevel usa
 	case ContractLevelUsage:
 		uri = apiContractLevelUsage
 	default:
-		return StoragesUsage{}, invalidUsageQueryLevel
+		return DistributedStoragesUsage{}, invalidUsageQueryLevel
 	}
 	r := gsRequest{
 		uri:                 path.Join(uri, "distributed_storages"),
@@ -567,7 +622,7 @@ func (c *Client) GetDistributedStoragesUsage(ctx context.Context, queryLevel usa
 		skipCheckingRequest: true,
 		queryParameters:     queryParam,
 	}
-	var response StoragesUsage
+	var response DistributedStoragesUsage
 	err := r.execute(ctx, *c, &response)
 	return response, err
 }
@@ -580,7 +635,7 @@ func (c *Client) GetDistributedStoragesUsage(ctx context.Context, queryLevel usa
 //		- intervalVariable (Optional, can be empty ""): HourIntervalVariable, DayIntervalVariable, WeekIntervalVariable, MonthIntervalVariable, or "".
 //
 // See: https://gridscale.io/en/api-documentation/index.html#operation/ProjectLevelRocketStorageUsageGet
-func (c *Client) GetRocketStoragesUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted bool, intervalVariable string) (StoragesUsage, error) {
+func (c *Client) GetRocketStoragesUsage(ctx context.Context, queryLevel usageQueryLevel, fromTime GSTime, toTime *GSTime, withoutDeleted bool, intervalVariable string) (RocketStoragesUsage, error) {
 	queryParam := map[string]string{
 		"from_time":         fromTime.String(),
 		"without_deleted":   strconv.FormatBool(withoutDeleted),
@@ -596,7 +651,7 @@ func (c *Client) GetRocketStoragesUsage(ctx context.Context, queryLevel usageQue
 	case ContractLevelUsage:
 		uri = apiContractLevelUsage
 	default:
-		return StoragesUsage{}, invalidUsageQueryLevel
+		return RocketStoragesUsage{}, invalidUsageQueryLevel
 	}
 	r := gsRequest{
 		uri:                 path.Join(uri, "rocket_storages"),
@@ -604,7 +659,7 @@ func (c *Client) GetRocketStoragesUsage(ctx context.Context, queryLevel usageQue
 		skipCheckingRequest: true,
 		queryParameters:     queryParam,
 	}
-	var response StoragesUsage
+	var response RocketStoragesUsage
 	err := r.execute(ctx, *c, &response)
 	return response, err
 }

--- a/usage_test.go
+++ b/usage_test.go
@@ -1,0 +1,2009 @@
+package gsclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"path"
+	"testing"
+	"time"
+)
+
+func TestClient_GetGeneralUsage(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	mux.HandleFunc(apiProjectLevelUsage, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet(""))
+	})
+	mux.HandleFunc(apiContractLevelUsage, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet(""))
+	})
+	type args struct {
+		ctx              context.Context
+		queryLevel       usageQueryLevel
+		fromTime         GSTime
+		toTime           *GSTime
+		withoutDeleted   bool
+		intervalVariable string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    GeneralUsage
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Successful Project level GetGeneralUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockGeneralUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetGeneralUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockGeneralUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetGeneralUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockGeneralUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetGeneralUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockGeneralUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetGeneralUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockGeneralUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetGeneralUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockGeneralUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetGeneralUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockGeneralUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetGeneralUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockGeneralUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Invalid query level GetGeneralUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       100000,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    GeneralUsage{},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetGeneralUsage(tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetGeneralUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "GetGeneralUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+		})
+	}
+}
+
+func TestClient_GetServersUsage(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	projectServerURI := path.Join(apiProjectLevelUsage, "servers")
+	contractServerURI := path.Join(apiContractLevelUsage, "servers")
+	mux.HandleFunc(projectServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("servers"))
+	})
+	mux.HandleFunc(contractServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("servers"))
+	})
+	type args struct {
+		ctx              context.Context
+		queryLevel       usageQueryLevel
+		fromTime         GSTime
+		toTime           *GSTime
+		withoutDeleted   bool
+		intervalVariable string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    ServersUsage
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Successful Project level GetServersUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockServersUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetServersUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockServersUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetServersUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockServersUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetServersUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockServersUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetServersUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockServersUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetServersUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockServersUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetServersUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockServersUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetServersUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockServersUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Invalid query level GetServersUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       100000,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    ServersUsage{},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetServersUsage(tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetServersUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "GetServersUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+		})
+	}
+}
+
+func TestClient_GetDistributedStoragesUsage(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	projectServerURI := path.Join(apiProjectLevelUsage, "distributed_storages")
+	contractServerURI := path.Join(apiContractLevelUsage, "distributed_storages")
+	mux.HandleFunc(projectServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("storages"))
+	})
+	mux.HandleFunc(contractServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("storages"))
+	})
+	type args struct {
+		ctx              context.Context
+		queryLevel       usageQueryLevel
+		fromTime         GSTime
+		toTime           *GSTime
+		withoutDeleted   bool
+		intervalVariable string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    StoragesUsage
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Successful Project level GetDistributedStoragesUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockStoragesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetDistributedStoragesUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockStoragesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetDistributedStoragesUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockStoragesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetDistributedStoragesUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockStoragesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetDistributedStoragesUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockStoragesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetDistributedStoragesUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockStoragesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetDistributedStoragesUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockStoragesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetDistributedStoragesUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockStoragesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Invalid query level GetDistributedStoragesUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       100000,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    StoragesUsage{},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetDistributedStoragesUsage(tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetDistributedStoragesUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "GetDistributedStoragesUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+		})
+	}
+}
+
+func TestClient_GetRocketStoragesUsage(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	projectServerURI := path.Join(apiProjectLevelUsage, "rocket_storages")
+	contractServerURI := path.Join(apiContractLevelUsage, "rocket_storages")
+	mux.HandleFunc(projectServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("storages"))
+	})
+	mux.HandleFunc(contractServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("storages"))
+	})
+	type args struct {
+		ctx              context.Context
+		queryLevel       usageQueryLevel
+		fromTime         GSTime
+		toTime           *GSTime
+		withoutDeleted   bool
+		intervalVariable string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    StoragesUsage
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Successful Project level GetRocketStoragesUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockStoragesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetRocketStoragesUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockStoragesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetRocketStoragesUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockStoragesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetRocketStoragesUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockStoragesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetRocketStoragesUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockStoragesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetRocketStoragesUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockStoragesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetRocketStoragesUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockStoragesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetRocketStoragesUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockStoragesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Invalid query level GetRocketStoragesUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       100000,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    StoragesUsage{},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetRocketStoragesUsage(tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetRocketStoragesUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "GetRocketStoragesUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+		})
+	}
+}
+
+func TestClient_GetStorageBackupsUsage(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	projectServerURI := path.Join(apiProjectLevelUsage, "storage_backups")
+	contractServerURI := path.Join(apiContractLevelUsage, "storage_backups")
+	mux.HandleFunc(projectServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("storage_backups"))
+	})
+	mux.HandleFunc(contractServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("storage_backups"))
+	})
+	type args struct {
+		ctx              context.Context
+		queryLevel       usageQueryLevel
+		fromTime         GSTime
+		toTime           *GSTime
+		withoutDeleted   bool
+		intervalVariable string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    StorageBackupsUsage
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Successful Project level GetStorageBackupsUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockStorageBackupsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetStorageBackupsUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockStorageBackupsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetStorageBackupsUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockStorageBackupsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetStorageBackupsUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockStorageBackupsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetStorageBackupsUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockStorageBackupsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetStorageBackupsUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockStorageBackupsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetStorageBackupsUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockStorageBackupsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetStorageBackupsUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockStorageBackupsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Invalid query level GetStorageBackupsUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       100000,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    StorageBackupsUsage{},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetStorageBackupsUsage(tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetStorageBackupsUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "GetStorageBackupsUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+		})
+	}
+}
+
+func TestClient_GetSnapshotsUsage(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	projectServerURI := path.Join(apiProjectLevelUsage, "snapshots")
+	contractServerURI := path.Join(apiContractLevelUsage, "snapshots")
+	mux.HandleFunc(projectServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("snapshots"))
+	})
+	mux.HandleFunc(contractServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("snapshots"))
+	})
+	type args struct {
+		ctx              context.Context
+		queryLevel       usageQueryLevel
+		fromTime         GSTime
+		toTime           *GSTime
+		withoutDeleted   bool
+		intervalVariable string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    SnapshotsUsage
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Successful Project level GetSnapshotsUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockSnapshotsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetSnapshotsUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockSnapshotsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetSnapshotsUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockSnapshotsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetSnapshotsUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockSnapshotsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetSnapshotsUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockSnapshotsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetSnapshotsUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockSnapshotsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetSnapshotsUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockSnapshotsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetSnapshotsUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockSnapshotsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Invalid query level GetSnapshotsUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       100000,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    SnapshotsUsage{},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetSnapshotsUsage(tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetSnapshotsUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "GetSnapshotsUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+		})
+	}
+}
+
+func TestClient_GetTemplatesUsage(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	projectServerURI := path.Join(apiProjectLevelUsage, "templates")
+	contractServerURI := path.Join(apiContractLevelUsage, "templates")
+	mux.HandleFunc(projectServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("templates"))
+	})
+	mux.HandleFunc(contractServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("templates"))
+	})
+	type args struct {
+		ctx              context.Context
+		queryLevel       usageQueryLevel
+		fromTime         GSTime
+		toTime           *GSTime
+		withoutDeleted   bool
+		intervalVariable string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    TemplatesUsage
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Successful Project level GetTemplatesUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockTemplatesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetTemplatesUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockTemplatesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetTemplatesUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockTemplatesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetTemplatesUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockTemplatesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetTemplatesUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockTemplatesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetTemplatesUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockTemplatesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetTemplatesUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockTemplatesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetTemplatesUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockTemplatesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Invalid query level GetTemplatesUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       100000,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    TemplatesUsage{},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetTemplatesUsage(tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetTemplatesUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "GetTemplatesUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+		})
+	}
+}
+
+func TestClient_GetISOImagesUsage(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	projectServerURI := path.Join(apiProjectLevelUsage, "iso_images")
+	contractServerURI := path.Join(apiContractLevelUsage, "iso_images")
+	mux.HandleFunc(projectServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("iso_images"))
+	})
+	mux.HandleFunc(contractServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("iso_images"))
+	})
+	type args struct {
+		ctx              context.Context
+		queryLevel       usageQueryLevel
+		fromTime         GSTime
+		toTime           *GSTime
+		withoutDeleted   bool
+		intervalVariable string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    ISOImagesUsage
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Successful Project level GetISOImagesUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockISOImagesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetISOImagesUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockISOImagesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetISOImagesUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockISOImagesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetISOImagesUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockISOImagesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetISOImagesUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockISOImagesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetISOImagesUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockISOImagesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetISOImagesUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockISOImagesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetISOImagesUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockISOImagesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Invalid query level GetISOImagesUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       100000,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    ISOImagesUsage{},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetISOImagesUsage(tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetISOImagesUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "GetISOImagesUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+		})
+	}
+}
+
+func TestClient_GetIPsUsage(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	projectServerURI := path.Join(apiProjectLevelUsage, "ip_addresses")
+	contractServerURI := path.Join(apiContractLevelUsage, "ip_addresses")
+	mux.HandleFunc(projectServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("ip_addresses"))
+	})
+	mux.HandleFunc(contractServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("ip_addresses"))
+	})
+	type args struct {
+		ctx              context.Context
+		queryLevel       usageQueryLevel
+		fromTime         GSTime
+		toTime           *GSTime
+		withoutDeleted   bool
+		intervalVariable string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    IPsUsage
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Successful Project level GetIPsUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockIPsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetIPsUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockIPsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetIPsUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockIPsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetIPsUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockIPsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetIPsUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockIPsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetIPsUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockIPsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetIPsUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockIPsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetIPsUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockIPsUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Invalid query level GetIPsUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       100000,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    IPsUsage{},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetIPsUsage(tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetIPsUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "GetIPsUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+		})
+	}
+}
+
+func TestClient_GetLoadBalancersUsage(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	projectServerURI := path.Join(apiProjectLevelUsage, "load_balancers")
+	contractServerURI := path.Join(apiContractLevelUsage, "load_balancers")
+	mux.HandleFunc(projectServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("load_balancers"))
+	})
+	mux.HandleFunc(contractServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("load_balancers"))
+	})
+	type args struct {
+		ctx              context.Context
+		queryLevel       usageQueryLevel
+		fromTime         GSTime
+		toTime           *GSTime
+		withoutDeleted   bool
+		intervalVariable string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    LoadBalancersUsage
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Successful Project level GetLoadBalancersUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockLoadBalancersUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetLoadBalancersUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockLoadBalancersUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetLoadBalancersUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockLoadBalancersUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetLoadBalancersUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockLoadBalancersUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetLoadBalancersUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockLoadBalancersUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetLoadBalancersUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockLoadBalancersUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetLoadBalancersUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockLoadBalancersUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetLoadBalancersUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockLoadBalancersUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Invalid query level GetLoadBalancersUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       100000,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    LoadBalancersUsage{},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetLoadBalancersUsage(tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetLoadBalancersUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "GetLoadBalancersUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+		})
+	}
+}
+
+func TestClient_GetPaaSServicesUsage(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	projectServerURI := path.Join(apiProjectLevelUsage, "paas_services")
+	contractServerURI := path.Join(apiContractLevelUsage, "paas_services")
+	mux.HandleFunc(projectServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("paas_services"))
+	})
+	mux.HandleFunc(contractServerURI, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprint(w, prepareResourceUsageGet("paas_services"))
+	})
+	type args struct {
+		ctx              context.Context
+		queryLevel       usageQueryLevel
+		fromTime         GSTime
+		toTime           *GSTime
+		withoutDeleted   bool
+		intervalVariable string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    PaaSServicesUsage
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Successful Project level GetPaaSServicesUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockPaaSServicesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetPaaSServicesUsage with toTime=nil, withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           nil,
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockPaaSServicesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetPaaSServicesUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockPaaSServicesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetPaaSServicesUsage with withoutDeleted=false, intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   false,
+				intervalVariable: "",
+			},
+			want:    getMockPaaSServicesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetPaaSServicesUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockPaaSServicesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetPaaSServicesUsage with intervalVariable=\"\"",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: "",
+			},
+			want:    getMockPaaSServicesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Project level GetPaaSServicesUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ProjectLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockPaaSServicesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Successful Contract level GetPaaSServicesUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       ContractLevelUsage,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    getMockPaaSServicesUsage(),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Invalid query level GetPaaSServicesUsage",
+			args: args{
+				ctx:              context.Background(),
+				queryLevel:       100000,
+				fromTime:         GSTime{time.Now().Add(-24 * time.Hour)},
+				toTime:           &GSTime{time.Now()},
+				withoutDeleted:   true,
+				intervalVariable: HourIntervalVariable,
+			},
+			want:    PaaSServicesUsage{},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetPaaSServicesUsage(tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetPaaSServicesUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "GetPaaSServicesUsage(%v, %v, %v, %v, %v, %v)", tt.args.ctx, tt.args.queryLevel, tt.args.fromTime, tt.args.toTime, tt.args.withoutDeleted, tt.args.intervalVariable)
+		})
+	}
+}
+
+var dummyRsCurrentUsagePerMinute = []Usage{{
+	ProductNumber: 1,
+	Value:         2,
+}}
+
+var dummyRsUsagePerInterval = []UsagePerInterval{{
+	IntervalStart: dummyTime,
+	IntervalEnd:   dummyTime,
+	AccumulatedUsage: []Usage{{
+		ProductNumber: 1,
+		Value:         2,
+	}},
+}}
+
+func getMockGeneralUsage() GeneralUsage {
+	dummyRsUsageInfo := ResourceUsageInfo{
+		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+		UsagePerInterval:      dummyRsUsagePerInterval,
+	}
+	mock := GeneralUsage{
+		Servers:             dummyRsUsageInfo,
+		RocketStorages:      dummyRsUsageInfo,
+		DistributedStorages: dummyRsUsageInfo,
+		StorageBackups:      dummyRsUsageInfo,
+		Snapshots:           dummyRsUsageInfo,
+		Templates:           dummyRsUsageInfo,
+		IsoImages:           dummyRsUsageInfo,
+		IPAddresses:         dummyRsUsageInfo,
+		LoadBalancers:       dummyRsUsageInfo,
+		PaaSServices:        dummyRsUsageInfo,
+	}
+	return mock
+}
+
+func getMockServersUsage() ServersUsage {
+	mock := ServersUsage{
+		ObjectUUID:            dummyUUID,
+		Name:                  "test",
+		Memory:                2,
+		Cores:                 1,
+		Power:                 true,
+		Labels:                []string{"test"},
+		Deleted:               false,
+		Status:                "active",
+		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+		UsagePerInterval:      dummyRsUsagePerInterval,
+	}
+	return mock
+}
+
+func getMockStoragesUsage() StoragesUsage {
+	mock := StoragesUsage{
+		ObjectUUID:            dummyUUID,
+		ParentUUID:            dummyUUID,
+		Name:                  "test",
+		Labels:                []string{"test"},
+		Deleted:               false,
+		Status:                "active",
+		StorageType:           string(InsaneStorageType),
+		LastUsedTemplate:      "",
+		Capacity:              1000,
+		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+		UsagePerInterval:      dummyRsUsagePerInterval,
+	}
+	return mock
+}
+
+func getMockStorageBackupsUsage() StorageBackupsUsage {
+	mock := StorageBackupsUsage{
+		ObjectUUID:            dummyUUID,
+		Name:                  "test",
+		CreateTime:            dummyTime,
+		ChangeTime:            dummyTime,
+		Capacity:              1000,
+		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+		UsagePerInterval:      dummyRsUsagePerInterval,
+	}
+	return mock
+}
+
+func getMockSnapshotsUsage() SnapshotsUsage {
+	mock := SnapshotsUsage{
+		ObjectUUID:            dummyUUID,
+		Name:                  "test",
+		ParentUUID:            dummyUUID,
+		ParentName:            "test",
+		ProjectUUID:           dummyUUID,
+		Labels:                nil,
+		Status:                "active",
+		CreateTime:            dummyTime,
+		ChangeTime:            dummyTime,
+		Capacity:              1000,
+		Deleted:               false,
+		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+		UsagePerInterval:      dummyRsUsagePerInterval,
+	}
+	return mock
+}
+
+func getMockTemplatesUsage() TemplatesUsage {
+	mock := TemplatesUsage{
+		ObjectUUID:            dummyUUID,
+		Name:                  "test",
+		Status:                "active",
+		Ostype:                "linux",
+		Version:               "0.1",
+		CreateTime:            dummyTime,
+		ChangeTime:            dummyTime,
+		Private:               false,
+		LicenseProductNo:      0,
+		Capacity:              1000,
+		Distro:                "ubuntu",
+		Description:           "test",
+		Labels:                nil,
+		ProjectUUID:           dummyUUID,
+		Deleted:               false,
+		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+		UsagePerInterval:      dummyRsUsagePerInterval,
+	}
+	return mock
+}
+
+func getMockISOImagesUsage() ISOImagesUsage {
+	mock := ISOImagesUsage{
+		ObjectUUID:            dummyUUID,
+		Name:                  "test",
+		Description:           "test",
+		SourceURL:             "https://example.com",
+		Labels:                nil,
+		Status:                "active",
+		CreateTime:            dummyTime,
+		ChangeTime:            dummyTime,
+		Version:               "0.1",
+		Private:               true,
+		Capacity:              1000,
+		ProjectUUID:           dummyUUID,
+		Deleted:               false,
+		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+		UsagePerInterval:      dummyRsUsagePerInterval,
+	}
+	return mock
+}
+
+func getMockIPsUsage() IPsUsage {
+	mock := IPsUsage{
+		ObjectUUID:            dummyUUID,
+		Name:                  "test",
+		IP:                    "192.168.1.1",
+		Family:                0,
+		CreateTime:            dummyTime,
+		ChangeTime:            dummyTime,
+		Status:                "active",
+		LocationCountry:       "test",
+		LocationName:          "test",
+		LocationIata:          "test",
+		LocationUUID:          dummyUUID,
+		Prefix:                "192.168.1.1",
+		DeleteBlock:           false,
+		Failover:              false,
+		Labels:                nil,
+		ReverseDNS:            "192.168.2.1",
+		PartnerUUID:           dummyUUID,
+		ProjectUUID:           dummyUUID,
+		Deleted:               false,
+		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+		UsagePerInterval:      dummyRsUsagePerInterval,
+	}
+	return mock
+}
+
+func getMockLoadBalancersUsage() LoadBalancersUsage {
+	mock := LoadBalancersUsage{
+		ObjectUUID: dummyUUID,
+		Name:       "test",
+		ForwardingRules: []ForwardingRule{
+			{
+				LetsencryptSSL: nil,
+				ListenPort:     8080,
+				Mode:           "http",
+				TargetPort:     8000,
+			},
+		},
+		BackendServers: []BackendServer{
+			{
+				Weight: 100,
+				Host:   "185.201.147.176",
+			},
+		},
+		CreateTime:            dummyTime,
+		ChangeTime:            dummyTime,
+		Status:                "active",
+		RedirectHTTPToHTTPS:   false,
+		Algorithm:             "leastconn",
+		ListenIPv6UUID:        dummyUUID,
+		ListenIPv4UUID:        dummyUUID,
+		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+		UsagePerInterval:      dummyRsUsagePerInterval,
+	}
+	return mock
+}
+
+func getMockPaaSServicesUsage() PaaSServicesUsage {
+	mock := PaaSServicesUsage{
+		ObjectUUID: dummyUUID,
+		Name:       "test",
+		Status:     "active",
+		Credentials: []Credential{
+			{
+				Username: "username",
+				Password: "password",
+				Type:     "type",
+			},
+		},
+		CreateTime:          dummyTime,
+		ChangeTime:          dummyTime,
+		ServiceTemplateUUID: dummyUUID,
+		Parameters: map[string]interface{}{
+			"TEST_PARAM": "test value",
+		},
+		ResourceLimits: []ResourceLimit{
+			{
+				Resource: "cpu",
+				Limit:    2,
+			},
+		},
+		ProjectUUID:           dummyUUID,
+		Deleted:               false,
+		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+		UsagePerInterval:      dummyRsUsagePerInterval,
+	}
+	return mock
+}
+
+func prepareResourceUsageGet(resourceName string) string {
+	var usage interface{}
+	switch resourceName {
+	case "servers":
+		usage = getMockServersUsage()
+	case "storages":
+		usage = getMockStoragesUsage()
+	case "storage_backups":
+		usage = getMockStorageBackupsUsage()
+	case "snapshots":
+		usage = getMockSnapshotsUsage()
+	case "templates":
+		usage = getMockTemplatesUsage()
+	case "iso_images":
+		usage = getMockISOImagesUsage()
+	case "ip_addresses":
+		usage = getMockIPsUsage()
+	case "load_balancers":
+		usage = getMockLoadBalancersUsage()
+	case "paas_services":
+		usage = getMockPaaSServicesUsage()
+	default:
+		usage = getMockGeneralUsage()
+	}
+	res, _ := json.Marshal(usage)
+	return string(res)
+}

--- a/usage_test.go
+++ b/usage_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"path"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_GetGeneralUsage(t *testing.T) {
@@ -333,12 +334,12 @@ func TestClient_GetDistributedStoragesUsage(t *testing.T) {
 	mux.HandleFunc(projectServerURI, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
-		fmt.Fprint(w, prepareResourceUsageGet("storages"))
+		fmt.Fprint(w, prepareResourceUsageGet("distributed_storages"))
 	})
 	mux.HandleFunc(contractServerURI, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
-		fmt.Fprint(w, prepareResourceUsageGet("storages"))
+		fmt.Fprint(w, prepareResourceUsageGet("distributed_storages"))
 	})
 	type args struct {
 		ctx              context.Context
@@ -351,7 +352,7 @@ func TestClient_GetDistributedStoragesUsage(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    StoragesUsage
+		want    DistributedStoragesUsage
 		wantErr assert.ErrorAssertionFunc
 	}{
 		{
@@ -364,7 +365,7 @@ func TestClient_GetDistributedStoragesUsage(t *testing.T) {
 				withoutDeleted:   false,
 				intervalVariable: "",
 			},
-			want:    getMockStoragesUsage(),
+			want:    getMockDistributedStoragesUsage(),
 			wantErr: assert.NoError,
 		},
 		{
@@ -377,7 +378,7 @@ func TestClient_GetDistributedStoragesUsage(t *testing.T) {
 				withoutDeleted:   false,
 				intervalVariable: "",
 			},
-			want:    getMockStoragesUsage(),
+			want:    getMockDistributedStoragesUsage(),
 			wantErr: assert.NoError,
 		},
 		{
@@ -390,7 +391,7 @@ func TestClient_GetDistributedStoragesUsage(t *testing.T) {
 				withoutDeleted:   false,
 				intervalVariable: "",
 			},
-			want:    getMockStoragesUsage(),
+			want:    getMockDistributedStoragesUsage(),
 			wantErr: assert.NoError,
 		},
 		{
@@ -403,7 +404,7 @@ func TestClient_GetDistributedStoragesUsage(t *testing.T) {
 				withoutDeleted:   false,
 				intervalVariable: "",
 			},
-			want:    getMockStoragesUsage(),
+			want:    getMockDistributedStoragesUsage(),
 			wantErr: assert.NoError,
 		},
 		{
@@ -416,7 +417,7 @@ func TestClient_GetDistributedStoragesUsage(t *testing.T) {
 				withoutDeleted:   true,
 				intervalVariable: "",
 			},
-			want:    getMockStoragesUsage(),
+			want:    getMockDistributedStoragesUsage(),
 			wantErr: assert.NoError,
 		},
 		{
@@ -429,7 +430,7 @@ func TestClient_GetDistributedStoragesUsage(t *testing.T) {
 				withoutDeleted:   true,
 				intervalVariable: "",
 			},
-			want:    getMockStoragesUsage(),
+			want:    getMockDistributedStoragesUsage(),
 			wantErr: assert.NoError,
 		},
 		{
@@ -442,7 +443,7 @@ func TestClient_GetDistributedStoragesUsage(t *testing.T) {
 				withoutDeleted:   true,
 				intervalVariable: HourIntervalVariable,
 			},
-			want:    getMockStoragesUsage(),
+			want:    getMockDistributedStoragesUsage(),
 			wantErr: assert.NoError,
 		},
 		{
@@ -455,7 +456,7 @@ func TestClient_GetDistributedStoragesUsage(t *testing.T) {
 				withoutDeleted:   true,
 				intervalVariable: HourIntervalVariable,
 			},
-			want:    getMockStoragesUsage(),
+			want:    getMockDistributedStoragesUsage(),
 			wantErr: assert.NoError,
 		},
 		{
@@ -468,7 +469,7 @@ func TestClient_GetDistributedStoragesUsage(t *testing.T) {
 				withoutDeleted:   true,
 				intervalVariable: HourIntervalVariable,
 			},
-			want:    StoragesUsage{},
+			want:    DistributedStoragesUsage{},
 			wantErr: assert.Error,
 		},
 	}
@@ -491,12 +492,12 @@ func TestClient_GetRocketStoragesUsage(t *testing.T) {
 	mux.HandleFunc(projectServerURI, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
-		fmt.Fprint(w, prepareResourceUsageGet("storages"))
+		fmt.Fprint(w, prepareResourceUsageGet("rocket_storages"))
 	})
 	mux.HandleFunc(contractServerURI, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		w.Header().Set(requestUUIDHeader, dummyRequestUUID)
-		fmt.Fprint(w, prepareResourceUsageGet("storages"))
+		fmt.Fprint(w, prepareResourceUsageGet("rocket_storages"))
 	})
 	type args struct {
 		ctx              context.Context
@@ -509,7 +510,7 @@ func TestClient_GetRocketStoragesUsage(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    StoragesUsage
+		want    RocketStoragesUsage
 		wantErr assert.ErrorAssertionFunc
 	}{
 		{
@@ -522,7 +523,7 @@ func TestClient_GetRocketStoragesUsage(t *testing.T) {
 				withoutDeleted:   false,
 				intervalVariable: "",
 			},
-			want:    getMockStoragesUsage(),
+			want:    getMockRocketStoragesUsage(),
 			wantErr: assert.NoError,
 		},
 		{
@@ -535,7 +536,7 @@ func TestClient_GetRocketStoragesUsage(t *testing.T) {
 				withoutDeleted:   false,
 				intervalVariable: "",
 			},
-			want:    getMockStoragesUsage(),
+			want:    getMockRocketStoragesUsage(),
 			wantErr: assert.NoError,
 		},
 		{
@@ -548,7 +549,7 @@ func TestClient_GetRocketStoragesUsage(t *testing.T) {
 				withoutDeleted:   false,
 				intervalVariable: "",
 			},
-			want:    getMockStoragesUsage(),
+			want:    getMockRocketStoragesUsage(),
 			wantErr: assert.NoError,
 		},
 		{
@@ -561,7 +562,7 @@ func TestClient_GetRocketStoragesUsage(t *testing.T) {
 				withoutDeleted:   false,
 				intervalVariable: "",
 			},
-			want:    getMockStoragesUsage(),
+			want:    getMockRocketStoragesUsage(),
 			wantErr: assert.NoError,
 		},
 		{
@@ -574,7 +575,7 @@ func TestClient_GetRocketStoragesUsage(t *testing.T) {
 				withoutDeleted:   true,
 				intervalVariable: "",
 			},
-			want:    getMockStoragesUsage(),
+			want:    getMockRocketStoragesUsage(),
 			wantErr: assert.NoError,
 		},
 		{
@@ -587,7 +588,7 @@ func TestClient_GetRocketStoragesUsage(t *testing.T) {
 				withoutDeleted:   true,
 				intervalVariable: "",
 			},
-			want:    getMockStoragesUsage(),
+			want:    getMockRocketStoragesUsage(),
 			wantErr: assert.NoError,
 		},
 		{
@@ -600,7 +601,7 @@ func TestClient_GetRocketStoragesUsage(t *testing.T) {
 				withoutDeleted:   true,
 				intervalVariable: HourIntervalVariable,
 			},
-			want:    getMockStoragesUsage(),
+			want:    getMockRocketStoragesUsage(),
 			wantErr: assert.NoError,
 		},
 		{
@@ -613,7 +614,7 @@ func TestClient_GetRocketStoragesUsage(t *testing.T) {
 				withoutDeleted:   true,
 				intervalVariable: HourIntervalVariable,
 			},
-			want:    getMockStoragesUsage(),
+			want:    getMockRocketStoragesUsage(),
 			wantErr: assert.NoError,
 		},
 		{
@@ -626,7 +627,7 @@ func TestClient_GetRocketStoragesUsage(t *testing.T) {
 				withoutDeleted:   true,
 				intervalVariable: HourIntervalVariable,
 			},
-			want:    StoragesUsage{},
+			want:    RocketStoragesUsage{},
 			wantErr: assert.Error,
 		},
 	}
@@ -1767,216 +1768,255 @@ func getMockGeneralUsage() GeneralUsage {
 		UsagePerInterval:      dummyRsUsagePerInterval,
 	}
 	mock := GeneralUsage{
-		Servers:             dummyRsUsageInfo,
-		RocketStorages:      dummyRsUsageInfo,
-		DistributedStorages: dummyRsUsageInfo,
-		StorageBackups:      dummyRsUsageInfo,
-		Snapshots:           dummyRsUsageInfo,
-		Templates:           dummyRsUsageInfo,
-		IsoImages:           dummyRsUsageInfo,
-		IPAddresses:         dummyRsUsageInfo,
-		LoadBalancers:       dummyRsUsageInfo,
-		PaaSServices:        dummyRsUsageInfo,
+		ResourcesUsage: GeneralUsageProperties{
+			Servers:             dummyRsUsageInfo,
+			RocketStorages:      dummyRsUsageInfo,
+			DistributedStorages: dummyRsUsageInfo,
+			StorageBackups:      dummyRsUsageInfo,
+			Snapshots:           dummyRsUsageInfo,
+			Templates:           dummyRsUsageInfo,
+			IsoImages:           dummyRsUsageInfo,
+			IPAddresses:         dummyRsUsageInfo,
+			LoadBalancers:       dummyRsUsageInfo,
+			PaaSServices:        dummyRsUsageInfo,
+		},
 	}
 	return mock
 }
 
 func getMockServersUsage() ServersUsage {
 	mock := ServersUsage{
-		ObjectUUID:            dummyUUID,
-		Name:                  "test",
-		Memory:                2,
-		Cores:                 1,
-		Power:                 true,
-		Labels:                []string{"test"},
-		Deleted:               false,
-		Status:                "active",
-		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
-		UsagePerInterval:      dummyRsUsagePerInterval,
-	}
+		ResourcesUsage: []ServerUsageProperties{{
+			ObjectUUID:            dummyUUID,
+			Name:                  "test",
+			Memory:                2,
+			Cores:                 1,
+			Power:                 true,
+			Labels:                []string{"test"},
+			Deleted:               false,
+			Status:                "active",
+			CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+			UsagePerInterval:      dummyRsUsagePerInterval,
+		},
+		}}
 	return mock
 }
 
-func getMockStoragesUsage() StoragesUsage {
-	mock := StoragesUsage{
-		ObjectUUID:            dummyUUID,
-		ParentUUID:            dummyUUID,
-		Name:                  "test",
-		Labels:                []string{"test"},
-		Deleted:               false,
-		Status:                "active",
-		StorageType:           string(InsaneStorageType),
-		LastUsedTemplate:      "",
-		Capacity:              1000,
-		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
-		UsagePerInterval:      dummyRsUsagePerInterval,
-	}
+func getMockDistributedStoragesUsage() DistributedStoragesUsage {
+	mock := DistributedStoragesUsage{
+		ResourcesUsage: []StorageUsageProperties{{
+			ObjectUUID:            dummyUUID,
+			ParentUUID:            dummyUUID,
+			Name:                  "test",
+			Labels:                []string{"test"},
+			Deleted:               false,
+			Status:                "active",
+			StorageType:           string(InsaneStorageType),
+			LastUsedTemplate:      "",
+			Capacity:              1000,
+			CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+			UsagePerInterval:      dummyRsUsagePerInterval,
+		},
+		}}
+	return mock
+}
+
+func getMockRocketStoragesUsage() RocketStoragesUsage {
+	mock := RocketStoragesUsage{
+		ResourcesUsage: []StorageUsageProperties{{
+			ObjectUUID:            dummyUUID,
+			ParentUUID:            dummyUUID,
+			Name:                  "test",
+			Labels:                []string{"test"},
+			Deleted:               false,
+			Status:                "active",
+			StorageType:           string(InsaneStorageType),
+			LastUsedTemplate:      "",
+			Capacity:              1000,
+			CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+			UsagePerInterval:      dummyRsUsagePerInterval,
+		},
+		}}
 	return mock
 }
 
 func getMockStorageBackupsUsage() StorageBackupsUsage {
 	mock := StorageBackupsUsage{
-		ObjectUUID:            dummyUUID,
-		Name:                  "test",
-		CreateTime:            dummyTime,
-		ChangeTime:            dummyTime,
-		Capacity:              1000,
-		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
-		UsagePerInterval:      dummyRsUsagePerInterval,
-	}
+		ResourcesUsage: []StorageBackupUsageProperties{{
+			ObjectUUID:            dummyUUID,
+			Name:                  "test",
+			CreateTime:            dummyTime,
+			ChangeTime:            dummyTime,
+			Capacity:              1000,
+			CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+			UsagePerInterval:      dummyRsUsagePerInterval,
+		},
+		}}
 	return mock
 }
 
 func getMockSnapshotsUsage() SnapshotsUsage {
 	mock := SnapshotsUsage{
-		ObjectUUID:            dummyUUID,
-		Name:                  "test",
-		ParentUUID:            dummyUUID,
-		ParentName:            "test",
-		ProjectUUID:           dummyUUID,
-		Labels:                nil,
-		Status:                "active",
-		CreateTime:            dummyTime,
-		ChangeTime:            dummyTime,
-		Capacity:              1000,
-		Deleted:               false,
-		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
-		UsagePerInterval:      dummyRsUsagePerInterval,
-	}
+		ResourcesUsage: []SnapshotUsageProperties{{
+			ObjectUUID:            dummyUUID,
+			Name:                  "test",
+			ParentUUID:            dummyUUID,
+			ParentName:            "test",
+			ProjectUUID:           dummyUUID,
+			Labels:                nil,
+			Status:                "active",
+			CreateTime:            dummyTime,
+			ChangeTime:            dummyTime,
+			Capacity:              1000,
+			Deleted:               false,
+			CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+			UsagePerInterval:      dummyRsUsagePerInterval,
+		},
+		}}
 	return mock
 }
 
 func getMockTemplatesUsage() TemplatesUsage {
 	mock := TemplatesUsage{
-		ObjectUUID:            dummyUUID,
-		Name:                  "test",
-		Status:                "active",
-		Ostype:                "linux",
-		Version:               "0.1",
-		CreateTime:            dummyTime,
-		ChangeTime:            dummyTime,
-		Private:               false,
-		LicenseProductNo:      0,
-		Capacity:              1000,
-		Distro:                "ubuntu",
-		Description:           "test",
-		Labels:                nil,
-		ProjectUUID:           dummyUUID,
-		Deleted:               false,
-		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
-		UsagePerInterval:      dummyRsUsagePerInterval,
-	}
+		ResourcesUsage: []TemplateUsageProperties{{
+			ObjectUUID:            dummyUUID,
+			Name:                  "test",
+			Status:                "active",
+			Ostype:                "linux",
+			Version:               "0.1",
+			CreateTime:            dummyTime,
+			ChangeTime:            dummyTime,
+			Private:               false,
+			LicenseProductNo:      0,
+			Capacity:              1000,
+			Distro:                "ubuntu",
+			Description:           "test",
+			Labels:                nil,
+			ProjectUUID:           dummyUUID,
+			Deleted:               false,
+			CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+			UsagePerInterval:      dummyRsUsagePerInterval,
+		},
+		}}
 	return mock
 }
 
 func getMockISOImagesUsage() ISOImagesUsage {
 	mock := ISOImagesUsage{
-		ObjectUUID:            dummyUUID,
-		Name:                  "test",
-		Description:           "test",
-		SourceURL:             "https://example.com",
-		Labels:                nil,
-		Status:                "active",
-		CreateTime:            dummyTime,
-		ChangeTime:            dummyTime,
-		Version:               "0.1",
-		Private:               true,
-		Capacity:              1000,
-		ProjectUUID:           dummyUUID,
-		Deleted:               false,
-		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
-		UsagePerInterval:      dummyRsUsagePerInterval,
-	}
+		ResourcesUsage: []ISOImageUsageProperties{{
+			ObjectUUID:            dummyUUID,
+			Name:                  "test",
+			Description:           "test",
+			SourceURL:             "https://example.com",
+			Labels:                nil,
+			Status:                "active",
+			CreateTime:            dummyTime,
+			ChangeTime:            dummyTime,
+			Version:               "0.1",
+			Private:               true,
+			Capacity:              1000,
+			ProjectUUID:           dummyUUID,
+			Deleted:               false,
+			CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+			UsagePerInterval:      dummyRsUsagePerInterval,
+		},
+		}}
 	return mock
 }
 
 func getMockIPsUsage() IPsUsage {
 	mock := IPsUsage{
-		ObjectUUID:            dummyUUID,
-		Name:                  "test",
-		IP:                    "192.168.1.1",
-		Family:                0,
-		CreateTime:            dummyTime,
-		ChangeTime:            dummyTime,
-		Status:                "active",
-		LocationCountry:       "test",
-		LocationName:          "test",
-		LocationIata:          "test",
-		LocationUUID:          dummyUUID,
-		Prefix:                "192.168.1.1",
-		DeleteBlock:           false,
-		Failover:              false,
-		Labels:                nil,
-		ReverseDNS:            "192.168.2.1",
-		PartnerUUID:           dummyUUID,
-		ProjectUUID:           dummyUUID,
-		Deleted:               false,
-		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
-		UsagePerInterval:      dummyRsUsagePerInterval,
-	}
+		ResourcesUsage: []IPUsageProperties{{
+			ObjectUUID:            dummyUUID,
+			Name:                  "test",
+			IP:                    "192.168.1.1",
+			Family:                0,
+			CreateTime:            dummyTime,
+			ChangeTime:            dummyTime,
+			Status:                "active",
+			LocationCountry:       "test",
+			LocationName:          "test",
+			LocationIata:          "test",
+			LocationUUID:          dummyUUID,
+			Prefix:                "192.168.1.1",
+			DeleteBlock:           false,
+			Failover:              false,
+			Labels:                nil,
+			ReverseDNS:            "192.168.2.1",
+			PartnerUUID:           dummyUUID,
+			ProjectUUID:           dummyUUID,
+			Deleted:               false,
+			CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+			UsagePerInterval:      dummyRsUsagePerInterval,
+		},
+		}}
 	return mock
 }
 
 func getMockLoadBalancersUsage() LoadBalancersUsage {
 	mock := LoadBalancersUsage{
-		ObjectUUID: dummyUUID,
-		Name:       "test",
-		ForwardingRules: []ForwardingRule{
-			{
-				LetsencryptSSL: nil,
-				ListenPort:     8080,
-				Mode:           "http",
-				TargetPort:     8000,
+		ResourcesUsage: []LoadBalancerUsageProperties{{
+			ObjectUUID: dummyUUID,
+			Name:       "test",
+			ForwardingRules: []ForwardingRule{
+				{
+					LetsencryptSSL: nil,
+					ListenPort:     8080,
+					Mode:           "http",
+					TargetPort:     8000,
+				},
 			},
-		},
-		BackendServers: []BackendServer{
-			{
-				Weight: 100,
-				Host:   "185.201.147.176",
+			BackendServers: []BackendServer{
+				{
+					Weight: 100,
+					Host:   "185.201.147.176",
+				},
 			},
+			CreateTime:            dummyTime,
+			ChangeTime:            dummyTime,
+			Status:                "active",
+			RedirectHTTPToHTTPS:   false,
+			Algorithm:             "leastconn",
+			ListenIPv6UUID:        dummyUUID,
+			ListenIPv4UUID:        dummyUUID,
+			CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+			UsagePerInterval:      dummyRsUsagePerInterval,
 		},
-		CreateTime:            dummyTime,
-		ChangeTime:            dummyTime,
-		Status:                "active",
-		RedirectHTTPToHTTPS:   false,
-		Algorithm:             "leastconn",
-		ListenIPv6UUID:        dummyUUID,
-		ListenIPv4UUID:        dummyUUID,
-		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
-		UsagePerInterval:      dummyRsUsagePerInterval,
-	}
+		}}
 	return mock
 }
 
 func getMockPaaSServicesUsage() PaaSServicesUsage {
 	mock := PaaSServicesUsage{
-		ObjectUUID: dummyUUID,
-		Name:       "test",
-		Status:     "active",
-		Credentials: []Credential{
-			{
-				Username: "username",
-				Password: "password",
-				Type:     "type",
+		ResourcesUsage: []PaaSServiceUsageProperties{{
+			ObjectUUID: dummyUUID,
+			Name:       "test",
+			Status:     "active",
+			Credentials: []Credential{
+				{
+					Username: "username",
+					Password: "password",
+					Type:     "type",
+				},
 			},
-		},
-		CreateTime:          dummyTime,
-		ChangeTime:          dummyTime,
-		ServiceTemplateUUID: dummyUUID,
-		Parameters: map[string]interface{}{
-			"TEST_PARAM": "test value",
-		},
-		ResourceLimits: []ResourceLimit{
-			{
-				Resource: "cpu",
-				Limit:    2,
+			CreateTime:          dummyTime,
+			ChangeTime:          dummyTime,
+			ServiceTemplateUUID: dummyUUID,
+			Parameters: map[string]interface{}{
+				"TEST_PARAM": "test value",
 			},
+			ResourceLimits: []ResourceLimit{
+				{
+					Resource: "cpu",
+					Limit:    2,
+				},
+			},
+			ProjectUUID:           dummyUUID,
+			Deleted:               false,
+			CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
+			UsagePerInterval:      dummyRsUsagePerInterval,
 		},
-		ProjectUUID:           dummyUUID,
-		Deleted:               false,
-		CurrentUsagePerMinute: dummyRsCurrentUsagePerMinute,
-		UsagePerInterval:      dummyRsUsagePerInterval,
-	}
+		}}
 	return mock
 }
 
@@ -1985,8 +2025,10 @@ func prepareResourceUsageGet(resourceName string) string {
 	switch resourceName {
 	case "servers":
 		usage = getMockServersUsage()
-	case "storages":
-		usage = getMockStoragesUsage()
+	case "distributed_storages":
+		usage = getMockDistributedStoragesUsage()
+	case "rocket_storages":
+		usage = getMockRocketStoragesUsage()
 	case "storage_backups":
 		usage = getMockStorageBackupsUsage()
 	case "snapshots":


### PR DESCRIPTION
Ref #208. Changes:
- Add usage getters (general, servers, distributed storages, rocket storages, storage backups, snapshots, templates, ISO Images, IP addresses, load balancers, PaaS services).
- Add unit tests for the new usage getter methods.
- Allow query parameters to `gsRequest`.
- More robust debugging log (print the URL after preparing the request).
- Add method `String()` to `GSTime` struct to allow represent `GSTime` in the desired string.