### PR TITLE
Add backup location to storage backup schedule.

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,6 +30,7 @@ const (
 	apiSSLCertificateBase         = "/objects/certificates"
 	apiProjectLevelUsage          = "/projects/usage"
 	apiContractLevelUsage         = "/contracts/usage"
+	apiBackupLocationBase         = "/objects/backup_locations"
 )
 
 // Client struct of a gridscale golang client.

--- a/storage_backup_schedule.go
+++ b/storage_backup_schedule.go
@@ -62,6 +62,12 @@ type StorageBackupScheduleProperties struct {
 
 	// Status of the schedule.
 	Active bool `json:"active"`
+
+	// The Location where your backup is stored.
+	BackupLocationUUID string `json:"backup_location_uuid"`
+
+	// The human-readable name of backup location. It supports the full UTF-8 character set, with a maximum of 64 characters.
+	BackupLocationName string `json:"backup_location_name"`
 }
 
 // StorageBackupScheduleRelations holds a list of relations between a storage backup schedule and storage backups.
@@ -100,6 +106,9 @@ type StorageBackupScheduleCreateRequest struct {
 
 	// Status of the schedule.
 	Active bool `json:"active"`
+
+	// The Location where your backup is stored.
+	BackupLocationUUID string `json:"backup_location_uuid,omitempty"`
 }
 
 // StorageBackupScheduleCreateResponse represents a response for creating a storage backup schedule.
@@ -130,6 +139,25 @@ type StorageBackupScheduleUpdateRequest struct {
 
 	// Status of the schedule. Optional.
 	Active *bool `json:"active,omitempty"`
+}
+
+// StorageBackupLocationList holds a list of available location to store your backup.
+type StorageBackupLocationList struct {
+	List map[string]StorageBackupLocationProperties `json:"backup_locations"`
+}
+
+//StorageBackupLocation represents a backup location.
+type StorageBackupLocation struct {
+	Properties StorageBackupLocationProperties
+}
+
+// StorageBackupLocationProperties represents a backup location's properties.
+type StorageBackupLocationProperties struct {
+	// UUID of the location.
+	ObjectUUID string `json:"object_uuid"`
+
+	// Name of the location.
+	Name string `json:"name"`
 }
 
 // GetStorageBackupScheduleList gets a list of available storage backup schedules based on a given storage's id.
@@ -216,4 +244,24 @@ func (c *Client) DeleteStorageBackupSchedule(ctx context.Context, storageID, sch
 		method: http.MethodDelete,
 	}
 	return r.execute(ctx, *c, nil)
+}
+
+// GetStorageBackupLocationList gets a list of available locations to store your backup.
+//
+// See: https://gridscale.io/en//api-documentation/index.html#operation/GetBackupLocations
+func (c *Client) GetStorageBackupLocationList(ctx context.Context) ([]StorageBackupLocation, error) {
+	r := gsRequest{
+		uri:                 apiBackupLocationBase,
+		method:              http.MethodGet,
+		skipCheckingRequest: true,
+	}
+	var response StorageBackupLocationList
+	var locationList []StorageBackupLocation
+	err := r.execute(ctx, *c, &response)
+	for _, locationProperties := range response.List {
+		locationList = append(locationList, StorageBackupLocation{
+			Properties: locationProperties,
+		})
+	}
+	return locationList, err
 }

--- a/storage_backup_schedule.go
+++ b/storage_backup_schedule.go
@@ -16,7 +16,7 @@ type StorageBackupScheduleOperator interface {
 	DeleteStorageBackupSchedule(ctx context.Context, storageID, scheduleID string) error
 }
 
-// StorageBackupScheduleList holds a list of storage backup schedules.
+// StorageBackupScheduleList contains a list of storage backup schedules.
 type StorageBackupScheduleList struct {
 	List map[string]StorageBackupScheduleProperties `json:"schedule_storage_backups"`
 }
@@ -26,7 +26,7 @@ type StorageBackupSchedule struct {
 	Properties StorageBackupScheduleProperties `json:"schedule_storage_backup"`
 }
 
-// StorageBackupScheduleProperties holds properties of a storage backup schedule.
+// StorageBackupScheduleProperties contains properties of a storage backup schedule.
 type StorageBackupScheduleProperties struct {
 	// Defines the date and time of the last object change.
 	ChangeTime GSTime `json:"change_time"`
@@ -63,14 +63,14 @@ type StorageBackupScheduleProperties struct {
 	// Status of the schedule.
 	Active bool `json:"active"`
 
-	// The Location where your backup is stored.
+	// The UUD of the location where your backup is stored.
 	BackupLocationUUID string `json:"backup_location_uuid"`
 
 	// The human-readable name of backup location. It supports the full UTF-8 character set, with a maximum of 64 characters.
 	BackupLocationName string `json:"backup_location_name"`
 }
 
-// StorageBackupScheduleRelations holds a list of relations between a storage backup schedule and storage backups.
+// StorageBackupScheduleRelations contains a list of relations between a storage backup schedule and storage backups.
 type StorageBackupScheduleRelations struct {
 	// Array of all related backups (backups taken by this storage backup schedule).
 	StorageBackups []StorageBackupScheduleRelation `json:"storages_backups"`
@@ -107,7 +107,7 @@ type StorageBackupScheduleCreateRequest struct {
 	// Status of the schedule.
 	Active bool `json:"active"`
 
-	// The Location where your backup is stored.
+	// The UUD of the location where your backup is stored.
 	BackupLocationUUID string `json:"backup_location_uuid,omitempty"`
 }
 
@@ -141,7 +141,7 @@ type StorageBackupScheduleUpdateRequest struct {
 	Active *bool `json:"active,omitempty"`
 }
 
-// StorageBackupLocationList holds a list of available location to store your backup.
+// StorageBackupLocationList contains a list of available location to store your backup.
 type StorageBackupLocationList struct {
 	List map[string]StorageBackupLocationProperties `json:"backup_locations"`
 }
@@ -160,7 +160,7 @@ type StorageBackupLocationProperties struct {
 	Name string `json:"name"`
 }
 
-// GetStorageBackupScheduleList gets a list of available storage backup schedules based on a given storage's id.
+// GetStorageBackupScheduleList returns a list of available storage backup schedules based on a given storage's id.
 //
 // See: https://gridscale.io/en//api-documentation/index.html#operation/getStorageBackupSchedules
 func (c *Client) GetStorageBackupScheduleList(ctx context.Context, id string) ([]StorageBackupSchedule, error) {
@@ -181,7 +181,7 @@ func (c *Client) GetStorageBackupScheduleList(ctx context.Context, id string) ([
 	return schedules, err
 }
 
-// GetStorageBackupSchedule gets a specific storage backup schedule based on a given storage's id and a backup schedule's id.
+// GetStorageBackupSchedule returns a specific storage backup schedule based on a given storage's id and a backup schedule's id.
 //
 // See: https://gridscale.io/en//api-documentation/index.html#operation/getStorageBackupSchedules
 func (c *Client) GetStorageBackupSchedule(ctx context.Context, storageID, scheduleID string) (StorageBackupSchedule, error) {
@@ -246,7 +246,7 @@ func (c *Client) DeleteStorageBackupSchedule(ctx context.Context, storageID, sch
 	return r.execute(ctx, *c, nil)
 }
 
-// GetStorageBackupLocationList gets a list of available locations to store your backup.
+// GetStorageBackupLocationList returns a list of available locations to store your backup.
 //
 // See: https://gridscale.io/en//api-documentation/index.html#operation/GetBackupLocations
 func (c *Client) GetStorageBackupLocationList(ctx context.Context) ([]StorageBackupLocation, error) {

--- a/storage_backup_schedule.go
+++ b/storage_backup_schedule.go
@@ -63,7 +63,7 @@ type StorageBackupScheduleProperties struct {
 	// Status of the schedule.
 	Active bool `json:"active"`
 
-	// The UUD of the location where your backup is stored.
+	// The UUID of the location where your backup is stored.
 	BackupLocationUUID string `json:"backup_location_uuid"`
 
 	// The human-readable name of backup location. It supports the full UTF-8 character set, with a maximum of 64 characters.
@@ -107,7 +107,7 @@ type StorageBackupScheduleCreateRequest struct {
 	// Status of the schedule.
 	Active bool `json:"active"`
 
-	// The UUD of the location where your backup is stored.
+	// The UUID of the location where your backup is stored.
 	BackupLocationUUID string `json:"backup_location_uuid,omitempty"`
 }
 

--- a/storage_backup_schedule_test.go
+++ b/storage_backup_schedule_test.go
@@ -163,6 +163,35 @@ func TestClient_DeleteStorageBackupSchedule(t *testing.T) {
 	}
 }
 
+func TestClient_GetStorageBackupLocationList(t *testing.T) {
+	server, client, mux := setupTestClient(true)
+	defer server.Close()
+	uri := apiBackupLocationBase
+	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, http.MethodGet, request.Method)
+		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
+		fmt.Fprintf(writer, prepareBackupLocationListHTTPGet())
+	})
+	res, err := client.GetStorageBackupLocationList(emptyCtx)
+	assert.Nil(t, err, "GetStorageBackupLocationList returned an error %v", err)
+	assert.Equal(t, 1, len(res))
+	assert.Equal(t, fmt.Sprintf("[%v]", getMockBackupLocation()), fmt.Sprintf("%v", res))
+}
+
+func getMockBackupLocation() StorageBackupLocation {
+	mock := StorageBackupLocation{Properties: StorageBackupLocationProperties{
+		ObjectUUID: dummyUUID,
+		Name:       "test backup location",
+	}}
+	return mock
+}
+
+func prepareBackupLocationListHTTPGet() string {
+	location := getMockBackupLocation()
+	res, _ := json.Marshal(location.Properties)
+	return fmt.Sprintf(`{"backup_locations" : {"%s" : %s}}`, dummyUUID, string(res))
+}
+
 func getMockStorageBackupSchedule(status string) StorageBackupSchedule {
 	mock := StorageBackupSchedule{Properties: StorageBackupScheduleProperties{
 		ChangeTime:  dummyTime,


### PR DESCRIPTION
Ref #210. Changes:
- Add storage backup location API endpoint.
- Add method `GetStorageBackupLocationList` to fetch a list of available location used to store backups.
- Allow users to set location for backup in backup schedule.
- Update unit test.