### PR TITLE
Allow to attach PaaS service to a private network

### DIFF
--- a/network.go
+++ b/network.go
@@ -133,6 +133,9 @@ type NetworkRelations struct {
 
 	// Array of object (NetworkPaaSSecurityZone).
 	PaaSSecurityZones []NetworkPaaSSecurityZone `json:"paas_security_zones"`
+
+	// Array of PaaS services that are connected to this network.
+	PaaSServices []NetworkPaaSService `json:"paas_services"`
 }
 
 // NetworkVlan represents a relation between a network and a VLAN.
@@ -185,6 +188,25 @@ type NetworkPaaSSecurityZone struct {
 
 	// The UUID of an object is always unique, and refers to a specific object.
 	ObjectUUID string `json:"object_uuid"`
+}
+
+// NetworkPaaSService represents a relation between a network and a Network.
+type NetworkPaaSService struct {
+	// The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
+	ObjectName string `json:"object_name"`
+
+	// The UUID of an object is always unique, and refers to a specific object.
+	ObjectUUID string `json:"object_uuid"`
+
+	// Category of the PaaS service.
+	ServiceTemplateCategory string `json:"service_template_category"`
+
+	// The template used to create the service, you can find an available list at the /service_templates endpoint.
+	ServiceTemplateUUID string `json:"service_template_uuid"`
+
+	// Contains the IPv6/IPv4 address and port that the Service will listen to,
+	// you can use these details to connect internally to a service.
+	ListenPorts map[string]map[string]int `json:"listen_ports"`
 }
 
 // NetworkCreateRequest represents a request for creating a network.

--- a/paas.go
+++ b/paas.go
@@ -57,12 +57,15 @@ type PaaSServiceProperties struct {
 	// Defines the date and time the object was initially created.
 	CreateTime GSTime `json:"create_time"`
 
-	// Contains the IPv6 address and port that the Service will listen to,
+	// Contains the IPv6/IPv4 address and port that the Service will listen to,
 	// you can use these details to connect internally to a service.
 	ListenPorts map[string]map[string]int `json:"listen_ports"`
 
 	// The UUID of the security zone that the service is running in.
 	SecurityZoneUUID string `json:"security_zone_uuid"`
+
+	// The UUID of the network that the service is running in.
+	NetworkUUID string `json:"network_uuid"`
 
 	// The template used to create the service, you can find an available list at the /service_templates endpoint.
 	ServiceTemplateUUID string `json:"service_template_uuid"`
@@ -120,6 +123,9 @@ type PaaSServiceCreateRequest struct {
 
 	// The UUID of the security zone that the service is running in.
 	PaaSSecurityZoneUUID string `json:"paas_security_zone_uuid,omitempty"`
+
+	// The UUID of the network that the service is running in.
+	NetworkUUID string `json:"network_uuid,omitempty"`
 
 	// A list of service resource limits.
 	ResourceLimits []ResourceLimit `json:"resource_limits,omitempty"`
@@ -314,6 +320,9 @@ type PaaSServiceUpdateRequest struct {
 
 	// The template that you want to use in the service, you can find an available list at the /service_templates endpoint.
 	PaaSServiceTemplateUUID string `json:"service_template_uuid,omitempty"`
+
+	// The UUID of the network that the service is running in.
+	NetworkUUID string `json:"network_uuid,omitempty"`
 }
 
 // PaaSServiceMetrics represents a list of metrics of a PaaS service.

--- a/paas.go
+++ b/paas.go
@@ -70,6 +70,9 @@ type PaaSServiceProperties struct {
 	// The template used to create the service, you can find an available list at the /service_templates endpoint.
 	ServiceTemplateUUID string `json:"service_template_uuid"`
 
+	// The template category used to create the service.
+	ServiceTemplateCategory string `json:"service_template_category"`
+
 	// Total minutes the object has been running.
 	UsageInMinutes int `json:"usage_in_minutes"`
 

--- a/paas.go
+++ b/paas.go
@@ -61,10 +61,10 @@ type PaaSServiceProperties struct {
 	// you can use these details to connect internally to a service.
 	ListenPorts map[string]map[string]int `json:"listen_ports"`
 
-	// The UUID of the security zone that the service is running in.
+	// The UUID of the security zone that the service is attached to.
 	SecurityZoneUUID string `json:"security_zone_uuid"`
 
-	// The UUID of the network that the service is running in.
+	// The UUID of the network that the service is attached to.
 	NetworkUUID string `json:"network_uuid"`
 
 	// The template used to create the service, you can find an available list at the /service_templates endpoint.
@@ -121,10 +121,10 @@ type PaaSServiceCreateRequest struct {
 	// The list of labels.
 	Labels []string `json:"labels,omitempty"`
 
-	// The UUID of the security zone that the service is running in.
+	// The UUID of the security zone that the service is attached to.
 	PaaSSecurityZoneUUID string `json:"paas_security_zone_uuid,omitempty"`
 
-	// The UUID of the network that the service is running in.
+	// The UUID of the network that the service is attached to.
 	NetworkUUID string `json:"network_uuid,omitempty"`
 
 	// A list of service resource limits.
@@ -321,7 +321,7 @@ type PaaSServiceUpdateRequest struct {
 	// The template that you want to use in the service, you can find an available list at the /service_templates endpoint.
 	PaaSServiceTemplateUUID string `json:"service_template_uuid,omitempty"`
 
-	// The UUID of the network that the service is running in.
+	// The UUID of the network that the service is attached to.
 	NetworkUUID string `json:"network_uuid,omitempty"`
 }
 


### PR DESCRIPTION
Changes:
- Add `network_uuid` to `PaaSServicePropertie` (GET), `PaaSServiceCreateRequest` (POST), `PaaSServiceUpdateRequest` (PATCH).
- Add list of `NetworkPaaSService` which shows relations of a network and PaaS services when getting a network.