### PR TITLE
add retry when error code 424 (locked object), 500

### DIFF
--- a/request.go
+++ b/request.go
@@ -235,7 +235,7 @@ func (r *gsRequest) retryHTTPRequest(ctx context.Context, cfg *Config) (string, 
 			json.Unmarshal(responseBodyBytes, &errorMessage)
 
 			switch statusCode {
-			case http.StatusServiceUnavailable:
+			case http.StatusServiceUnavailable, http.StatusFailedDependency, http.StatusInternalServerError:
 				// Get the delay (in second) for the next retry
 				delayDurationStr := resp.Header.Get(retryAfterHeader)
 				delayDuration, err := strconv.Atoi(delayDurationStr)


### PR DESCRIPTION
Changes:
- Add retry when the backend return http error code 424 (usually caused by locked object), or 500.