### PR TITLE
Naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,12 +210,12 @@ Not all endpoints have been implemented in this client, but new ones will be add
   * IP Events Get (GetIPEventList)
   * IP Version Get (GetIPVersion)
 * SSH-Keys
-  * SSH-Keys Get (GetSshkeyList)
-  * SSH-Key Get (GetSshkey)
-  * SSH-Key Create (CreateSshkey)
-  * SSH-Key Patch (UpdateSshkey)
-  * SSH-Key Delete (DeleteSshkey)
-  * SSH-Key's events Get (GetSshkeyEventList)
+  * SSH-Keys Get (GetSSHKeyList)
+  * SSH-Key Get (GetSSHKey)
+  * SSH-Key Create (CreateSSHKey)
+  * SSH-Key Patch (UpdateSSHKey)
+  * SSH-Key Delete (DeleteSSHKey)
+  * SSH-Key's events Get (GetSSHKeyEventList)
 * Template
   * Templates Get (GetTemplateList)
   * Template Get (GetTemplate)

--- a/client.go
+++ b/client.go
@@ -15,7 +15,7 @@ const (
 	apiStorageBase                = "/objects/storages"
 	apiNetworkBase                = "/objects/networks"
 	apiIPBase                     = "/objects/ips"
-	apiSshkeyBase                 = "/objects/sshkeys"
+	apiSSHKeyBase                 = "/objects/sshkeys"
 	apiTemplateBase               = "/objects/templates"
 	apiLoadBalancerBase           = "/objects/loadbalancers"
 	apiPaaSBase                   = "/objects/paas"

--- a/client.go
+++ b/client.go
@@ -46,8 +46,8 @@ func NewClient(c *Config) *Client {
 	return client
 }
 
-// HttpClient returns http client.
-func (c *Client) HttpClient() *http.Client {
+// HTTPClient returns http client.
+func (c *Client) HTTPClient() *http.Client {
 	return c.cfg.httpClient
 }
 

--- a/examples/sshkey.go
+++ b/examples/sshkey.go
@@ -23,11 +23,11 @@ func main() {
 
 	log.Info("Create SSH-key: Press 'Enter' to continue...")
 	bufio.NewReader(os.Stdin).ReadBytes('\n')
-	cSSHkey, err := client.CreateSshkey(
+	cSSHkey, err := client.CreateSSHKey(
 		emptyCtx,
-		gsclient.SshkeyCreateRequest{
+		gsclient.SSHKeyCreateRequest{
 			Name:   "go-client-ssh-key",
-			Sshkey: exampleSSHkey,
+			SSHKey: exampleSSHkey,
 		})
 	if err != nil {
 		log.Error("Create SSH-key has failed with error", err)
@@ -37,7 +37,7 @@ func main() {
 		"sshkey_uuid": cSSHkey.ObjectUUID,
 	}).Info("SSH-key successfully created")
 	defer func() {
-		err := client.DeleteSshkey(emptyCtx, cSSHkey.ObjectUUID)
+		err := client.DeleteSSHKey(emptyCtx, cSSHkey.ObjectUUID)
 		if err != nil {
 			log.Error("Delete SSH-key has failed with error", err)
 			return
@@ -46,7 +46,7 @@ func main() {
 	}()
 
 	// Get a SSH-key to update
-	sshkey, err := client.GetSshkey(emptyCtx, cSSHkey.ObjectUUID)
+	sshkey, err := client.GetSSHKey(emptyCtx, cSSHkey.ObjectUUID)
 	if err != nil {
 		log.Error("Get SSH-key has failed with error", err)
 		return
@@ -54,12 +54,12 @@ func main() {
 
 	log.Info("Update SSH-key: Press 'Enter' to continue...")
 	bufio.NewReader(os.Stdin).ReadBytes('\n')
-	err = client.UpdateSshkey(
+	err = client.UpdateSSHKey(
 		emptyCtx,
 		sshkey.Properties.ObjectUUID,
-		gsclient.SshkeyUpdateRequest{
+		gsclient.SSHKeyUpdateRequest{
 			Name:   "updated SSH-key",
-			Sshkey: sshkey.Properties.Sshkey,
+			SSHKey: sshkey.Properties.SSHKey,
 			Labels: &sshkey.Properties.Labels,
 		})
 	if err != nil {
@@ -70,7 +70,7 @@ func main() {
 
 	log.Info("Get SSH-key's events: Press 'Enter' to continue...")
 	bufio.NewReader(os.Stdin).ReadBytes('\n')
-	events, err := client.GetSshkeyEventList(emptyCtx, sshkey.Properties.ObjectUUID)
+	events, err := client.GetSSHKeyEventList(emptyCtx, sshkey.Properties.ObjectUUID)
 	if err != nil {
 		log.Error("Get SSH-key's events has failed with error", err)
 		return

--- a/sshkey.go
+++ b/sshkey.go
@@ -9,30 +9,30 @@ import (
 
 // SSHKeyOperator provides an interface for operations on SSH keys.
 type SSHKeyOperator interface {
-	GetSshkey(ctx context.Context, id string) (Sshkey, error)
-	GetSshkeyList(ctx context.Context) ([]Sshkey, error)
-	CreateSshkey(ctx context.Context, body SshkeyCreateRequest) (CreateResponse, error)
-	DeleteSshkey(ctx context.Context, id string) error
-	UpdateSshkey(ctx context.Context, id string, body SshkeyUpdateRequest) error
-	GetSshkeyEventList(ctx context.Context, id string) ([]Event, error)
+	GetSSHKey(ctx context.Context, id string) (SSHKey, error)
+	GetSSHKeyList(ctx context.Context) ([]SSHKey, error)
+	CreateSSHKey(ctx context.Context, body SSHKeyCreateRequest) (CreateResponse, error)
+	DeleteSSHKey(ctx context.Context, id string) error
+	UpdateSSHKey(ctx context.Context, id string, body SSHKeyUpdateRequest) error
+	GetSSHKeyEventList(ctx context.Context, id string) ([]Event, error)
 }
 
-// SshkeyList holds a list of SSH keys.
-type SshkeyList struct {
+// SSHKeyList holds a list of SSH keys.
+type SSHKeyList struct {
 	// Array of SSH keys.
-	List map[string]SshkeyProperties `json:"sshkeys"`
+	List map[string]SSHKeyProperties `json:"sshkeys"`
 }
 
-// Sshkey represents a single SSH key.
-type Sshkey struct {
+// SSHKey represents a single SSH key.
+type SSHKey struct {
 	// Properties of a SSH key.
-	Properties SshkeyProperties `json:"sshkey"`
+	Properties SSHKeyProperties `json:"sshkey"`
 }
 
-// SshkeyProperties holds properties of a single SSH key.
+// SSHKeyProperties holds properties of a single SSH key.
 // A SSH key can be retrieved when creating new storages and attaching them to
 // servers.
-type SshkeyProperties struct {
+type SSHKeyProperties struct {
 	// The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 	Name string `json:"name"`
 
@@ -49,7 +49,7 @@ type SshkeyProperties struct {
 	ChangeTime GSTime `json:"change_time"`
 
 	// The OpenSSH public key string (all key types are supported => ed25519, ecdsa, dsa, rsa, rsa1).
-	Sshkey string `json:"sshkey"`
+	SSHKey string `json:"sshkey"`
 
 	// List of labels.
 	Labels []string `json:"labels"`
@@ -58,73 +58,73 @@ type SshkeyProperties struct {
 	UserUUID string `json:"user_uuid"`
 }
 
-// SshkeyCreateRequest represents a request for creating a SSH key.
-type SshkeyCreateRequest struct {
+// SSHKeyCreateRequest represents a request for creating a SSH key.
+type SSHKeyCreateRequest struct {
 	// The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 	Name string `json:"name"`
 
 	// The OpenSSH public key string (all key types are supported => ed25519, ecdsa, dsa, rsa, rsa1).
-	Sshkey string `json:"sshkey"`
+	SSHKey string `json:"sshkey"`
 
 	// List of labels. Optional.
 	Labels []string `json:"labels,omitempty"`
 }
 
-// SshkeyUpdateRequest represents a request for updating a SSH key.
-type SshkeyUpdateRequest struct {
+// SSHKeyUpdateRequest represents a request for updating a SSH key.
+type SSHKeyUpdateRequest struct {
 	// The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 	// Optional.
 	Name string `json:"name,omitempty"`
 
 	// The OpenSSH public key string (all key types are supported => ed25519, ecdsa, dsa, rsa, rsa1). Optional.
-	Sshkey string `json:"sshkey,omitempty"`
+	SSHKey string `json:"sshkey,omitempty"`
 
 	// List of labels. Optional.
 	Labels *[]string `json:"labels,omitempty"`
 }
 
-// GetSshkey gets a single SSH key object.
+// GetSSHKey gets a single SSH key object.
 //
 // See: https://gridscale.io/en//api-documentation/index.html#operation/getSshKey
-func (c *Client) GetSshkey(ctx context.Context, id string) (Sshkey, error) {
+func (c *Client) GetSSHKey(ctx context.Context, id string) (SSHKey, error) {
 	if !isValidUUID(id) {
-		return Sshkey{}, errors.New("'id' is invalid")
+		return SSHKey{}, errors.New("'id' is invalid")
 	}
 	r := gsRequest{
-		uri:                 path.Join(apiSshkeyBase, id),
+		uri:                 path.Join(apiSSHKeyBase, id),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
 	}
-	var response Sshkey
+	var response SSHKey
 	err := r.execute(ctx, *c, &response)
 	return response, err
 }
 
-// GetSshkeyList gets the list of SSH keys in the project.
+// GetSSHKeyList gets the list of SSH keys in the project.
 //
 // See: https://gridscale.io/en//api-documentation/index.html#operation/getSshKeys
-func (c *Client) GetSshkeyList(ctx context.Context) ([]Sshkey, error) {
+func (c *Client) GetSSHKeyList(ctx context.Context) ([]SSHKey, error) {
 	r := gsRequest{
-		uri:                 apiSshkeyBase,
+		uri:                 apiSSHKeyBase,
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
 	}
 
-	var response SshkeyList
-	var sshKeys []Sshkey
+	var response SSHKeyList
+	var sshKeys []SSHKey
 	err := r.execute(ctx, *c, &response)
 	for _, properties := range response.List {
-		sshKeys = append(sshKeys, Sshkey{Properties: properties})
+		sshKeys = append(sshKeys, SSHKey{Properties: properties})
 	}
 	return sshKeys, err
 }
 
-// CreateSshkey creates a new SSH key.
+// CreateSSHKey creates a new SSH key.
 //
 // See: https://gridscale.io/en//api-documentation/index.html#operation/createSshKey
-func (c *Client) CreateSshkey(ctx context.Context, body SshkeyCreateRequest) (CreateResponse, error) {
+func (c *Client) CreateSSHKey(ctx context.Context, body SSHKeyCreateRequest) (CreateResponse, error) {
 	r := gsRequest{
-		uri:    apiSshkeyBase,
+		uri:    apiSSHKeyBase,
 		method: "POST",
 		body:   body,
 	}
@@ -133,44 +133,44 @@ func (c *Client) CreateSshkey(ctx context.Context, body SshkeyCreateRequest) (Cr
 	return response, err
 }
 
-// DeleteSshkey removes a single SSH key.
+// DeleteSSHKey removes a single SSH key.
 //
 // See: https://gridscale.io/en//api-documentation/index.html#operation/deleteSshKey
-func (c *Client) DeleteSshkey(ctx context.Context, id string) error {
+func (c *Client) DeleteSSHKey(ctx context.Context, id string) error {
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
 	r := gsRequest{
-		uri:    path.Join(apiSshkeyBase, id),
+		uri:    path.Join(apiSSHKeyBase, id),
 		method: http.MethodDelete,
 	}
 	return r.execute(ctx, *c, nil)
 }
 
-// UpdateSshkey updates a SSH key.
+// UpdateSSHKey updates a SSH key.
 //
 // See: https://gridscale.io/en//api-documentation/index.html#operation/updateSshKey
-func (c *Client) UpdateSshkey(ctx context.Context, id string, body SshkeyUpdateRequest) error {
+func (c *Client) UpdateSSHKey(ctx context.Context, id string, body SSHKeyUpdateRequest) error {
 	if !isValidUUID(id) {
 		return errors.New("'id' is invalid")
 	}
 	r := gsRequest{
-		uri:    path.Join(apiSshkeyBase, id),
+		uri:    path.Join(apiSSHKeyBase, id),
 		method: http.MethodPatch,
 		body:   body,
 	}
 	return r.execute(ctx, *c, nil)
 }
 
-// GetSshkeyEventList gets a SSH key's events.
+// GetSSHKeyEventList gets a SSH key's events.
 //
 // See: https://gridscale.io/en//api-documentation/index.html#operation/getSshKeyEvents
-func (c *Client) GetSshkeyEventList(ctx context.Context, id string) ([]Event, error) {
+func (c *Client) GetSSHKeyEventList(ctx context.Context, id string) ([]Event, error) {
 	if !isValidUUID(id) {
 		return nil, errors.New("'id' is invalid")
 	}
 	r := gsRequest{
-		uri:                 path.Join(apiSshkeyBase, id, "events"),
+		uri:                 path.Join(apiSSHKeyBase, id, "events"),
 		method:              http.MethodGet,
 		skipCheckingRequest: true,
 	}

--- a/sshkey_test.go
+++ b/sshkey_test.go
@@ -13,13 +13,13 @@ import (
 func TestClient_GetSshkeyList(t *testing.T) {
 	server, client, mux := setupTestClient(true)
 	defer server.Close()
-	uri := apiSshkeyBase
+	uri := apiSSHKeyBase
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
 		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareSshkeyListHTTPGet())
 	})
-	res, err := client.GetSshkeyList(emptyCtx)
+	res, err := client.GetSSHKeyList(emptyCtx)
 	assert.Nil(t, err, "GetSshkeyList returned an error %v", err)
 	assert.Equal(t, 1, len(res))
 	assert.Equal(t, fmt.Sprintf("[%v]", getMockSshkey("active")), fmt.Sprintf("%v", res))
@@ -28,14 +28,14 @@ func TestClient_GetSshkeyList(t *testing.T) {
 func TestClient_GetSshkey(t *testing.T) {
 	server, client, mux := setupTestClient(true)
 	defer server.Close()
-	uri := path.Join(apiSshkeyBase, dummyUUID)
+	uri := path.Join(apiSSHKeyBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
 		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprintf(writer, prepareSshkeyHTTPGet("active"))
 	})
 	for _, test := range uuidCommonTestCases {
-		res, err := client.GetSshkey(emptyCtx, test.testUUID)
+		res, err := client.GetSSHKey(emptyCtx, test.testUUID)
 		if test.isFailed {
 			assert.NotNil(t, err)
 		} else {
@@ -49,7 +49,7 @@ func TestClient_CreateSshkey(t *testing.T) {
 	server, client, mux := setupTestClient(true)
 	defer server.Close()
 	var isFailed bool
-	uri := apiSshkeyBase
+	uri := apiSSHKeyBase
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodPost, request.Method)
 		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
@@ -61,11 +61,11 @@ func TestClient_CreateSshkey(t *testing.T) {
 	})
 	for _, test := range commonSuccessFailTestCases {
 		isFailed = test.isFailed
-		response, err := client.CreateSshkey(
+		response, err := client.CreateSSHKey(
 			emptyCtx,
-			SshkeyCreateRequest{
+			SSHKeyCreateRequest{
 				Name:   "test",
-				Sshkey: "example",
+				SSHKey: "example",
 				Labels: []string{"label"},
 			})
 		if isFailed {
@@ -81,7 +81,7 @@ func TestClient_UpdateSshkey(t *testing.T) {
 	server, client, mux := setupTestClient(true)
 	defer server.Close()
 	var isFailed bool
-	uri := path.Join(apiSshkeyBase, dummyUUID)
+	uri := path.Join(apiSSHKeyBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
@@ -97,12 +97,12 @@ func TestClient_UpdateSshkey(t *testing.T) {
 	for _, serverTest := range commonSuccessFailTestCases {
 		isFailed = serverTest.isFailed
 		for _, test := range uuidCommonTestCases {
-			err := client.UpdateSshkey(
+			err := client.UpdateSSHKey(
 				emptyCtx,
 				test.testUUID,
-				SshkeyUpdateRequest{
+				SSHKeyUpdateRequest{
 					Name:   "test",
-					Sshkey: "example",
+					SSHKey: "example",
 				})
 			if test.isFailed || isFailed {
 				assert.NotNil(t, err)
@@ -117,7 +117,7 @@ func TestClient_DeleteSshkey(t *testing.T) {
 	server, client, mux := setupTestClient(true)
 	defer server.Close()
 	var isFailed bool
-	uri := path.Join(apiSshkeyBase, dummyUUID)
+	uri := path.Join(apiSSHKeyBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		if isFailed {
@@ -133,7 +133,7 @@ func TestClient_DeleteSshkey(t *testing.T) {
 	for _, serverTest := range commonSuccessFailTestCases {
 		isFailed = serverTest.isFailed
 		for _, test := range uuidCommonTestCases {
-			err := client.DeleteSshkey(emptyCtx, test.testUUID)
+			err := client.DeleteSSHKey(emptyCtx, test.testUUID)
 			if test.isFailed || isFailed {
 				assert.NotNil(t, err)
 			} else {
@@ -146,14 +146,14 @@ func TestClient_DeleteSshkey(t *testing.T) {
 func TestClient_GetSshkeyEventList(t *testing.T) {
 	server, client, mux := setupTestClient(true)
 	defer server.Close()
-	uri := path.Join(apiSshkeyBase, dummyUUID, "events")
+	uri := path.Join(apiSSHKeyBase, dummyUUID, "events")
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
 		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
 		fmt.Fprint(writer, prepareEventListHTTPGet())
 	})
 	for _, test := range uuidCommonTestCases {
-		res, err := client.GetSshkeyEventList(emptyCtx, test.testUUID)
+		res, err := client.GetSSHKeyEventList(emptyCtx, test.testUUID)
 		if test.isFailed {
 			assert.NotNil(t, err)
 		} else {
@@ -164,14 +164,14 @@ func TestClient_GetSshkeyEventList(t *testing.T) {
 	}
 }
 
-func getMockSshkey(status string) Sshkey {
-	mock := Sshkey{Properties: SshkeyProperties{
+func getMockSshkey(status string) SSHKey {
+	mock := SSHKey{Properties: SSHKeyProperties{
 		Name:       "test",
 		ObjectUUID: dummyUUID,
 		Status:     status,
 		CreateTime: dummyTime,
 		ChangeTime: dummyTime,
-		Sshkey:     "example",
+		SSHKey:     "example",
 		Labels:     []string{"label"},
 		UserUUID:   dummyUUID,
 	}}

--- a/sshkey_test.go
+++ b/sshkey_test.go
@@ -10,42 +10,42 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestClient_GetSshkeyList(t *testing.T) {
+func TestClient_GetSSHKeyList(t *testing.T) {
 	server, client, mux := setupTestClient(true)
 	defer server.Close()
 	uri := apiSSHKeyBase
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
 		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
-		fmt.Fprintf(writer, prepareSshkeyListHTTPGet())
+		fmt.Fprintf(writer, prepareSSHKeyListHTTPGet())
 	})
 	res, err := client.GetSSHKeyList(emptyCtx)
-	assert.Nil(t, err, "GetSshkeyList returned an error %v", err)
+	assert.Nil(t, err, "GetSSHKeyList returned an error %v", err)
 	assert.Equal(t, 1, len(res))
-	assert.Equal(t, fmt.Sprintf("[%v]", getMockSshkey("active")), fmt.Sprintf("%v", res))
+	assert.Equal(t, fmt.Sprintf("[%v]", getMockSSHKey("active")), fmt.Sprintf("%v", res))
 }
 
-func TestClient_GetSshkey(t *testing.T) {
+func TestClient_GetSSHKey(t *testing.T) {
 	server, client, mux := setupTestClient(true)
 	defer server.Close()
 	uri := path.Join(apiSSHKeyBase, dummyUUID)
 	mux.HandleFunc(uri, func(writer http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)
 		writer.Header().Set(requestUUIDHeader, dummyRequestUUID)
-		fmt.Fprintf(writer, prepareSshkeyHTTPGet("active"))
+		fmt.Fprintf(writer, prepareSSHKeyHTTPGet("active"))
 	})
 	for _, test := range uuidCommonTestCases {
 		res, err := client.GetSSHKey(emptyCtx, test.testUUID)
 		if test.isFailed {
 			assert.NotNil(t, err)
 		} else {
-			assert.Nil(t, err, "GetSshkey returned an error %v", err)
-			assert.Equal(t, fmt.Sprintf("%v", getMockSshkey("active")), fmt.Sprintf("%v", res))
+			assert.Nil(t, err, "GetSSHKey returned an error %v", err)
+			assert.Equal(t, fmt.Sprintf("%v", getMockSSHKey("active")), fmt.Sprintf("%v", res))
 		}
 	}
 }
 
-func TestClient_CreateSshkey(t *testing.T) {
+func TestClient_CreateSSHKey(t *testing.T) {
 	server, client, mux := setupTestClient(true)
 	defer server.Close()
 	var isFailed bool
@@ -56,7 +56,7 @@ func TestClient_CreateSshkey(t *testing.T) {
 		if isFailed {
 			writer.WriteHeader(400)
 		} else {
-			fmt.Fprintf(writer, prepareSshkeyCreateResponse())
+			fmt.Fprintf(writer, prepareSSHKeyCreateResponse())
 		}
 	})
 	for _, test := range commonSuccessFailTestCases {
@@ -71,13 +71,13 @@ func TestClient_CreateSshkey(t *testing.T) {
 		if isFailed {
 			assert.NotNil(t, err)
 		} else {
-			assert.Nil(t, err, "CreateSshkey returned an error %v", err)
-			assert.Equal(t, fmt.Sprintf("%v", getMockSshkeyCreateResponse()), fmt.Sprintf("%s", response))
+			assert.Nil(t, err, "CreateSSHKey returned an error %v", err)
+			assert.Equal(t, fmt.Sprintf("%v", getMockSSHKeyCreateResponse()), fmt.Sprintf("%s", response))
 		}
 	}
 }
 
-func TestClient_UpdateSshkey(t *testing.T) {
+func TestClient_UpdateSSHKey(t *testing.T) {
 	server, client, mux := setupTestClient(true)
 	defer server.Close()
 	var isFailed bool
@@ -90,7 +90,7 @@ func TestClient_UpdateSshkey(t *testing.T) {
 			if request.Method == http.MethodPatch {
 				fmt.Fprintf(writer, "")
 			} else if request.Method == http.MethodGet {
-				fmt.Fprint(writer, prepareSshkeyHTTPGet("active"))
+				fmt.Fprint(writer, prepareSSHKeyHTTPGet("active"))
 			}
 		}
 	})
@@ -107,13 +107,13 @@ func TestClient_UpdateSshkey(t *testing.T) {
 			if test.isFailed || isFailed {
 				assert.NotNil(t, err)
 			} else {
-				assert.Nil(t, err, "UpdateSshkey returned an error %v", err)
+				assert.Nil(t, err, "UpdateSSHKey returned an error %v", err)
 			}
 		}
 	}
 }
 
-func TestClient_DeleteSshkey(t *testing.T) {
+func TestClient_DeleteSSHKey(t *testing.T) {
 	server, client, mux := setupTestClient(true)
 	defer server.Close()
 	var isFailed bool
@@ -137,13 +137,13 @@ func TestClient_DeleteSshkey(t *testing.T) {
 			if test.isFailed || isFailed {
 				assert.NotNil(t, err)
 			} else {
-				assert.Nil(t, err, "DeleteSshkey returned an error %v", err)
+				assert.Nil(t, err, "DeleteSSHKey returned an error %v", err)
 			}
 		}
 	}
 }
 
-func TestClient_GetSshkeyEventList(t *testing.T) {
+func TestClient_GetSSHKeyEventList(t *testing.T) {
 	server, client, mux := setupTestClient(true)
 	defer server.Close()
 	uri := path.Join(apiSSHKeyBase, dummyUUID, "events")
@@ -157,14 +157,14 @@ func TestClient_GetSshkeyEventList(t *testing.T) {
 		if test.isFailed {
 			assert.NotNil(t, err)
 		} else {
-			assert.Nil(t, err, "GetSshkeyEventList returned an error %v", err)
+			assert.Nil(t, err, "GetSSHKeyEventList returned an error %v", err)
 			assert.Equal(t, 1, len(res))
 			assert.Equal(t, fmt.Sprintf("[%v]", getMockEvent()), fmt.Sprintf("%v", res))
 		}
 	}
 }
 
-func getMockSshkey(status string) SSHKey {
+func getMockSSHKey(status string) SSHKey {
 	mock := SSHKey{Properties: SSHKeyProperties{
 		Name:       "test",
 		ObjectUUID: dummyUUID,
@@ -178,7 +178,7 @@ func getMockSshkey(status string) SSHKey {
 	return mock
 }
 
-func getMockSshkeyCreateResponse() CreateResponse {
+func getMockSSHKeyCreateResponse() CreateResponse {
 	mock := CreateResponse{
 		ObjectUUID:  dummyUUID,
 		RequestUUID: dummyRequestUUID,
@@ -186,20 +186,20 @@ func getMockSshkeyCreateResponse() CreateResponse {
 	return mock
 }
 
-func prepareSshkeyListHTTPGet() string {
-	key := getMockSshkey("active")
+func prepareSSHKeyListHTTPGet() string {
+	key := getMockSSHKey("active")
 	res, _ := json.Marshal(key.Properties)
 	return fmt.Sprintf(`{"sshkeys": {"%s": %s}}`, dummyUUID, string(res))
 }
 
-func prepareSshkeyHTTPGet(status string) string {
-	key := getMockSshkey(status)
+func prepareSSHKeyHTTPGet(status string) string {
+	key := getMockSSHKey(status)
 	res, _ := json.Marshal(key)
 	return string(res)
 }
 
-func prepareSshkeyCreateResponse() string {
-	response := getMockSshkeyCreateResponse()
+func prepareSSHKeyCreateResponse() string {
+	response := getMockSSHKeyCreateResponse()
 	res, _ := json.Marshal(response)
 	return string(res)
 }

--- a/storage.go
+++ b/storage.go
@@ -202,7 +202,7 @@ type StorageAndSnapshotScheduleRelation struct {
 // the storage should be attached to a server later to create an Ubuntu 20.04 server.
 type StorageTemplate struct {
 	// List of SSH key UUIDs. Optional.
-	Sshkeys []string `json:"sshkeys,omitempty"`
+	SSHKeys []string `json:"sshkeys,omitempty"`
 
 	// The UUID of a template (public or private).
 	TemplateUUID string `json:"template_uuid"`

--- a/usage.go
+++ b/usage.go
@@ -526,7 +526,7 @@ const (
 	ContractLevelUsage = iota
 )
 
-var invalidUsageQueryLevel = errors.New("invalid Usage query level. Valid values: `gslclient.ProjectLevelUsage`, and `gslclient.ContractLevelUsage`")
+var errInvalidUsageQueryLevel = errors.New("invalid Usage query level. Valid values: `gslclient.ProjectLevelUsage`, and `gslclient.ContractLevelUsage`")
 
 // GetGeneralUsage returns general usage of all resources in project/contract level.
 // Args:
@@ -553,7 +553,7 @@ func (c *Client) GetGeneralUsage(ctx context.Context, queryLevel usageQueryLevel
 	case ContractLevelUsage:
 		uri = apiContractLevelUsage
 	default:
-		return GeneralUsage{}, invalidUsageQueryLevel
+		return GeneralUsage{}, errInvalidUsageQueryLevel
 	}
 	r := gsRequest{
 		uri:                 uri,
@@ -591,7 +591,7 @@ func (c *Client) GetServersUsage(ctx context.Context, queryLevel usageQueryLevel
 	case ContractLevelUsage:
 		uri = apiContractLevelUsage
 	default:
-		return ServersUsage{}, invalidUsageQueryLevel
+		return ServersUsage{}, errInvalidUsageQueryLevel
 	}
 	r := gsRequest{
 		uri:                 path.Join(uri, "servers"),
@@ -629,7 +629,7 @@ func (c *Client) GetDistributedStoragesUsage(ctx context.Context, queryLevel usa
 	case ContractLevelUsage:
 		uri = apiContractLevelUsage
 	default:
-		return DistributedStoragesUsage{}, invalidUsageQueryLevel
+		return DistributedStoragesUsage{}, errInvalidUsageQueryLevel
 	}
 	r := gsRequest{
 		uri:                 path.Join(uri, "distributed_storages"),
@@ -666,7 +666,7 @@ func (c *Client) GetRocketStoragesUsage(ctx context.Context, queryLevel usageQue
 	case ContractLevelUsage:
 		uri = apiContractLevelUsage
 	default:
-		return RocketStoragesUsage{}, invalidUsageQueryLevel
+		return RocketStoragesUsage{}, errInvalidUsageQueryLevel
 	}
 	r := gsRequest{
 		uri:                 path.Join(uri, "rocket_storages"),
@@ -704,7 +704,7 @@ func (c *Client) GetStorageBackupsUsage(ctx context.Context, queryLevel usageQue
 	case ContractLevelUsage:
 		uri = apiContractLevelUsage
 	default:
-		return StorageBackupsUsage{}, invalidUsageQueryLevel
+		return StorageBackupsUsage{}, errInvalidUsageQueryLevel
 	}
 	r := gsRequest{
 		uri:                 path.Join(uri, "storage_backups"),
@@ -742,7 +742,7 @@ func (c *Client) GetSnapshotsUsage(ctx context.Context, queryLevel usageQueryLev
 	case ContractLevelUsage:
 		uri = apiContractLevelUsage
 	default:
-		return SnapshotsUsage{}, invalidUsageQueryLevel
+		return SnapshotsUsage{}, errInvalidUsageQueryLevel
 	}
 	r := gsRequest{
 		uri:                 path.Join(uri, "snapshots"),
@@ -780,7 +780,7 @@ func (c *Client) GetTemplatesUsage(ctx context.Context, queryLevel usageQueryLev
 	case ContractLevelUsage:
 		uri = apiContractLevelUsage
 	default:
-		return TemplatesUsage{}, invalidUsageQueryLevel
+		return TemplatesUsage{}, errInvalidUsageQueryLevel
 	}
 	r := gsRequest{
 		uri:                 path.Join(uri, "templates"),
@@ -818,7 +818,7 @@ func (c *Client) GetISOImagesUsage(ctx context.Context, queryLevel usageQueryLev
 	case ContractLevelUsage:
 		uri = apiContractLevelUsage
 	default:
-		return ISOImagesUsage{}, invalidUsageQueryLevel
+		return ISOImagesUsage{}, errInvalidUsageQueryLevel
 	}
 	r := gsRequest{
 		uri:                 path.Join(uri, "iso_images"),
@@ -856,7 +856,7 @@ func (c *Client) GetIPsUsage(ctx context.Context, queryLevel usageQueryLevel, fr
 	case ContractLevelUsage:
 		uri = apiContractLevelUsage
 	default:
-		return IPsUsage{}, invalidUsageQueryLevel
+		return IPsUsage{}, errInvalidUsageQueryLevel
 	}
 	r := gsRequest{
 		uri:                 path.Join(uri, "ip_addresses"),
@@ -894,7 +894,7 @@ func (c *Client) GetLoadBalancersUsage(ctx context.Context, queryLevel usageQuer
 	case ContractLevelUsage:
 		uri = apiContractLevelUsage
 	default:
-		return LoadBalancersUsage{}, invalidUsageQueryLevel
+		return LoadBalancersUsage{}, errInvalidUsageQueryLevel
 	}
 	r := gsRequest{
 		uri:                 path.Join(uri, "load_balancers"),
@@ -932,7 +932,7 @@ func (c *Client) GetPaaSServicesUsage(ctx context.Context, queryLevel usageQuery
 	case ContractLevelUsage:
 		uri = apiContractLevelUsage
 	default:
-		return PaaSServicesUsage{}, invalidUsageQueryLevel
+		return PaaSServicesUsage{}, errInvalidUsageQueryLevel
 	}
 	r := gsRequest{
 		uri:                 path.Join(uri, "paas_services"),


### PR DESCRIPTION
Renames all variables, functions and types that had names not conforming to Go naming conventions

This will break the API and should only be pulled for the next major version

Fixes #181 when it's time for it

Linting should be added to the github workflow when this is pulled, as this fixes all current linting errors