### PR TITLE
Add new object for the hardware profile configuration

### DIFF
--- a/server.go
+++ b/server.go
@@ -57,7 +57,12 @@ type ServerProperties struct {
 	Cores int `json:"cores"`
 
 	// Specifies the hardware settings for the virtual machine.
+	// Note: hardware_profile and hardware_profile_config parameters can't be used at the same time.
 	HardwareProfile string `json:"hardware_profile"`
+
+	// Specifies the custom hardware settings for the virtual machine.
+	// Note: hardware_profile and hardware_profile_config parameters can't be used at the same time.
+	HardwareProfileConfig ServerHardwareProfileConfig `json:"hardware_profile_config"`
 
 	// Status indicates the status of the object. it could be in-provisioning or active
 	Status string `json:"status"`
@@ -135,7 +140,12 @@ type ServerCreateRequest struct {
 	// Specifies the hardware settings for the virtual machine.
 	// Allowed values: DefaultServerHardware, NestedServerHardware, LegacyServerHardware, CiscoCSRServerHardware,
 	// SophosUTMServerHardware, F5BigipServerHardware, Q35ServerHardware, Q35NestedServerHardware.
+	// Note: hardware_profile and hardware_profile_config parameters can't be used at the same time.
 	HardwareProfile ServerHardwareProfile `json:"hardware_profile,omitempty"`
+
+	// Specifies the custom hardware settings for the virtual machine.
+	// Note: hardware_profile and hardware_profile_config parameters can't be used at the same time.
+	HardwareProfileConfig ServerHardwareProfileConfig `json:"hardware_profile_config,omitempty"`
 
 	// Defines which Availability-Zone the Server is placed. Can be empty.
 	AvailablityZone string `json:"availability_zone,omitempty"`
@@ -250,7 +260,12 @@ type ServerUpdateRequest struct {
 	AutoRecovery *bool `json:"auto_recovery,omitempty"`
 
 	// Specifies the hardware settings for the virtual machine.
+	// Note: hardware_profile and hardware_profile_config parameters can't be used at the same time.
 	HardwareProfile ServerHardwareProfile `json:"hardware_profile,omitempty"`
+
+	// Specifies the custom hardware settings for the virtual machine.
+	// Note: hardware_profile and hardware_profile_config parameters can't be used at the same time.
+	HardwareProfileConfig ServerHardwareProfileConfig `json:"hardware_profile_config,omitempty"`
 }
 
 // ServerMetricList holds a list of a server's metrics.
@@ -308,6 +323,54 @@ const (
 	F5BigipServerHardware   ServerHardwareProfile = "f5_bigip"
 	Q35ServerHardware       ServerHardwareProfile = "q35"
 )
+
+type Machinetype string
+
+// All available machinetypes.
+const (
+	I440fxMachineType  Machinetype = "i440fx"
+	Q35BiosMachineType Machinetype = "q35_bios"
+	Q35Uefi            Machinetype = "q35_uefi"
+)
+
+type StorageDevice string
+
+// All available storage devices.
+const (
+	IDEStorageDevice         StorageDevice = "ide"
+	SATAStorageDevice        StorageDevice = "sata"
+	VirtIOSCSItorageDevice   StorageDevice = "virtio_scsi"
+	VirtIOBlockStorageDevice StorageDevice = "virtio_block"
+)
+
+type USBController string
+
+// All available USB controllers.
+const (
+	NecXHCIUSBController   USBController = "nec_xhci"
+	Piix3UHCIUSBController USBController = "piix3_uhc"
+)
+
+type NetworkModel string
+
+// All available network models.
+const (
+	E1000NetworkModel   NetworkModel = "e1000"
+	E1000ENetworkModel  NetworkModel = "e1000e"
+	VirtIONetworkModel  NetworkModel = "virtio"
+	VmxNet3NetworkModel NetworkModel = "vmxnet3"
+)
+
+type ServerHardwareProfileConfig struct {
+	Machinetype          Machinetype   `json:"machinetype"`
+	StorageDevice        StorageDevice `json:"storage_device"`
+	USBController        USBController `json:"usb_controller"`
+	NestedVirtualization bool          `json:"nested_virtualization"`
+	HyperVExtensions     bool          `json:"hyperv_extensions"`
+	NetworkModel         NetworkModel  `json:"network_model"`
+	SerialInterface      bool          `json:"serial_interface"`
+	ServerRenice         bool          `json:"server_renice"`
+}
 
 // GetServer gets a specific server based on given list.
 //


### PR DESCRIPTION
As described in request 4660, the CRUD endpoints for servers is/were extended with the possibility of a custom hardware profile. This pull request provides the corresponding changes for the Go client.