### PR TITLE
feat: expose additional location attributes on server

### DIFF
--- a/server.go
+++ b/server.go
@@ -70,6 +70,15 @@ type ServerProperties struct {
 	// Helps to identify which data center an object belongs to.
 	LocationUUID string `json:"location_uuid"`
 
+	// The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters.
+	LocationCountry string `json:"location_country"`
+
+	// Uses IATA airport code, which works as a location identifier.
+	LocationIata string `json:"location_iata"`
+
+	// The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters.
+	LocationName string `json:"location_name"`
+
 	// The power status of the server.
 	Power bool `json:"power"`
 


### PR DESCRIPTION
Some location attributes are missing on the server resource, although [according to the documentation](https://my.gridscale.io/APIDoc#tag/server/operation/getServers) they are provided by the API. This PR adds the additional attributes for unmarshaling.